### PR TITLE
adds missing props in sidebar breaking server

### DIFF
--- a/src/plugins/community/index.astro
+++ b/src/plugins/community/index.astro
@@ -10,11 +10,13 @@ import Step1 from '@assets/Step-1.png'
 import Step2 from '@assets/Step-2.png'
 import Step3 from '@assets/Step-3.png'
 import Key from '@assets/key.png'
+
+const { propertyAddress, name } = Astro.props
 ---
 
 <div class="relative">
   <CLBWrapper>
-    <Sidebar client:load />
+    <Sidebar client:load propertyAddress={propertyAddress} tenantName={name} />
     <article>
       <section class="mb-6">
         <!-- DIGEST -->

--- a/src/plugins/community/index.ts
+++ b/src/plugins/community/index.ts
@@ -7,8 +7,11 @@ import {
 import { default as Index } from './index.astro'
 import { default as Admin } from './admin.astro'
 
-export const getPagePaths: ClubsFunctionGetPagePaths = async () => [
-  { paths: ['community'], component: Index },
+export const getPagePaths: ClubsFunctionGetPagePaths = async (
+  _,
+  { name, propertyAddress }
+) => [
+  { paths: ['community'], component: Index, props: { name, propertyAddress } },
 ]
 
 export const getAdminPaths: ClubsFunctionGetAdminPaths = async (

--- a/src/plugins/quests/index.astro
+++ b/src/plugins/quests/index.astro
@@ -3,10 +3,12 @@ import CLBWrapper from '@components/Primitives/CLBWrapper.astro'
 
 import HSButton from '@components/Primitives/Hashi/HSButton.vue'
 import Sidebar from '@components/Sidebar/Sidebar.vue'
+
+const { propertyAddress, name } = Astro.props
 ---
 
 <CLBWrapper>
-  <Sidebar client:load />
+  <Sidebar client:load propertyAddress={propertyAddress} tenantName={name} />
   <section class="quests">
     <article class="mb-6">
       <h3 class="family-title text-lg mb-6">Quests</h3>

--- a/src/plugins/quests/index.ts
+++ b/src/plugins/quests/index.ts
@@ -14,7 +14,7 @@ export const getPagePaths: ClubsFunctionGetPagePaths = async (
   _,
   { propertyAddress, name }
 ) => [
-  { paths: ['quests'], component: Index },
+  { paths: ['quests'], component: Index, props: { propertyAddress, name } },
   ...questParams.map((param) => ({
     paths: ['quests', param],
     component: Id,


### PR DESCRIPTION
#### Description of the change

Community and Quests were not passing props to Sidebar, which was causing the server to break

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
