### PR TITLE
feat: add NFT gateway contact form server side membership check

### DIFF
--- a/src/fixtures/utility.ts
+++ b/src/fixtures/utility.ts
@@ -102,13 +102,16 @@ export const composeTiers = async ({
 }
 
 export const checkMemberships = async (
-  provider: ethers.providers.Web3Provider,
+  provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider,
   propertyAddress: string,
-  requiredMemberships: GatedMessageRequiredMemberships[]
+  requiredMemberships: GatedMessageRequiredMemberships[],
+  userAddress: string = "0x0000000000000000000000000000000000000000"
 ) => {
-  // gets the visitor's address
-  const signer = provider.getSigner()
-  const userAddress = await signer.getAddress()
+  if (userAddress === "0x0000000000000000000000000000000000000000") {
+    // gets the visitor's address
+    const signer = provider.getSigner()
+    userAddress = await signer.getAddress()
+  }
 
   // creates sTokens detector
   const clients = await clientsSTokens(provider)
@@ -149,7 +152,7 @@ export const checkMemberships = async (
         return tokenId
       }
 
-      return Promise.reject()
+      return Promise.reject("Membership not found")
     })
   )
 

--- a/src/fixtures/utility.ts
+++ b/src/fixtures/utility.ts
@@ -105,9 +105,11 @@ export const checkMemberships = async (
   provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider,
   propertyAddress: string,
   requiredMemberships: GatedMessageRequiredMemberships[],
-  userAddress: string = "0x0000000000000000000000000000000000000000"
+  userAddress: string = '0x0000000000000000000000000000000000000000'
 ) => {
-  if (userAddress === "0x0000000000000000000000000000000000000000") {
+  // Check if we are validating at server or ui. because server can
+  // provide userAddress.
+  if (userAddress === '0x0000000000000000000000000000000000000000') {
     // gets the visitor's address
     const signer = provider.getSigner()
     userAddress = await signer.getAddress()
@@ -152,7 +154,7 @@ export const checkMemberships = async (
         return tokenId
       }
 
-      return Promise.reject("Membership not found")
+      return Promise.reject('Membership not found')
     })
   )
 

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -6,22 +6,23 @@ import { checkMemberships } from '@fixtures/utility'
 import json from '../../../../plugins/message/forms.json'
 
 export const post = async ({ request }: { request: Request }) => {
-  const { site, data, sig, hash, userAddress, propertyAddress } = (await request.json()) as {
-    site: string
-    data: {
-      fullname: string
-      addressLine1: string
-      addressLine2: string
-      zipCode: string
-      city: string
-      country: string
-      formId: string
+  const { site, data, sig, hash, userAddress, propertyAddress } =
+    (await request.json()) as {
+      site: string
+      data: {
+        fullname: string
+        addressLine1: string
+        addressLine2: string
+        zipCode: string
+        city: string
+        country: string
+        formId: string
+      }
+      hash: string
+      sig: string
+      userAddress: string
+      propertyAddress: string
     }
-    hash: string
-    sig: string
-    userAddress: string
-    propertyAddress: string
-  }
 
   // Check that the user has signed the message.
   const verificationDigest = utils.hashMessage(hash)
@@ -46,18 +47,22 @@ export const post = async ({ request }: { request: Request }) => {
 
   // Check for required membership validity
   try {
-    const web3Provider = new ethers.providers.JsonRpcProvider(import.meta.env.PUBLIC_WEB3_PROVIDER_URL);
+    const web3Provider = new ethers.providers.JsonRpcProvider(
+      import.meta.env.PUBLIC_WEB3_PROVIDER_URL
+    )
     const isMember = await checkMemberships(
       web3Provider,
       propertyAddress,
       formData.requiredMemberships,
       userAddress
-    ).catch(err => { throw Error("Not a member") } )
+    ).catch((err) => {
+      throw Error('Not a member')
+    })
 
     if (!isMember) {
-      throw Error("Not a member");
+      throw Error('Not a member')
     }
-  } catch(error) {
+  } catch (error) {
     return new Response(JSON.stringify({ error }), { status: 500 })
   }
 

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -1,11 +1,12 @@
-import { utils, providers } from 'ethers'
+import { utils, providers, ethers, Signer } from 'ethers'
 import { createClient } from 'redis'
 import { authenticate } from '@devprotocol/clubs-core'
+import { checkMemberships } from '@fixtures/utility'
 
 import json from '../../../../plugins/message/forms.json'
 
 export const post = async ({ request }: { request: Request }) => {
-  const { site, data, sig, hash, userAddress } = (await request.json()) as {
+  const { site, data, sig, hash, userAddress, propertyAddress } = (await request.json()) as {
     site: string
     data: {
       fullname: string
@@ -19,6 +20,7 @@ export const post = async ({ request }: { request: Request }) => {
     hash: string
     sig: string
     userAddress: string
+    propertyAddress: string
   }
 
   // Check that the user has signed the message.
@@ -30,6 +32,7 @@ export const post = async ({ request }: { request: Request }) => {
     })
   }
 
+  // Check for form data validity.
   const formData = json.find((element) => element.id === Number(data.formId))
   if (!formData) {
     return new Response(JSON.stringify({ error: 'Form details not found' }), {
@@ -40,6 +43,23 @@ export const post = async ({ request }: { request: Request }) => {
   const provider = providers.getDefaultProvider(
     import.meta.env.PUBLIC_WEB3_PROVIDER_URL
   )
+
+  // Check for required membership validity
+  try {
+    const web3Provider = new ethers.providers.JsonRpcProvider(import.meta.env.PUBLIC_WEB3_PROVIDER_URL);
+    const isMember = await checkMemberships(
+      web3Provider,
+      propertyAddress,
+      formData.requiredMemberships,
+      userAddress
+    ).catch(err => { throw Error("Not a member") } )
+
+    if (!isMember) {
+      throw Error("Not a member");
+    }
+  } catch(error) {
+    return new Response(JSON.stringify({ error }), { status: 500 })
+  }
 
   const client = createClient({
     url: process.env.REDIS_URL,

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -22,8 +22,8 @@ export const post = async ({ request }: { request: Request }) => {
   }
 
   // Check that the user has signed the message.
-  const verificationDigest = utils.hashMessage(hash);
-  const recoveredSigner = utils.recoverAddress(verificationDigest, sig);
+  const verificationDigest = utils.hashMessage(hash)
+  const recoveredSigner = utils.recoverAddress(verificationDigest, sig)
   if (recoveredSigner.toLowerCase() !== userAddress.toLowerCase()) {
     return new Response(JSON.stringify({ error: 'Invalid signer' }), {
       status: 404,

--- a/src/plugins/message/components/MessageForm.vue
+++ b/src/plugins/message/components/MessageForm.vue
@@ -48,10 +48,10 @@ export default defineComponent({
   },
   methods: {
     async signAndSubmit() {
-      // if (!this.isMember) {
-      //   // TODO: update error state to show error message
-      //   return
-      // }
+      if (!this.isMember) {
+        // TODO: update error state to show error message
+        return
+      }
 
       const splitHostname = window.location.hostname.split('.')
       const site = splitHostname[0]
@@ -79,14 +79,13 @@ export default defineComponent({
       if (!sig) {
         return
       }
-      console.log(signer, await signer.getAddress())
       const body = {
         site,
         data,
         hash,
         sig,
         userAddress: await signer.getAddress(),
-        propertyAddress: this.propertyAddress
+        propertyAddress: this.propertyAddress,
       }
 
       try {
@@ -98,7 +97,6 @@ export default defineComponent({
         const success = res.ok
         this.messageSentStatus = success ? 'send-successful' : 'send-failed'
       } catch (e) {
-        console.log("ERROR", e);
         this.messageSentStatus = 'send-failed'
       }
     },

--- a/src/plugins/message/components/MessageForm.vue
+++ b/src/plugins/message/components/MessageForm.vue
@@ -79,13 +79,14 @@ export default defineComponent({
       if (!sig) {
         return
       }
-
+      console.log(signer, await signer.getAddress())
       const body = {
         site,
         data,
         hash,
         sig,
-        address: signer.address,
+        userAddress: await signer.getAddress(),
+        propertyAddress: this.propertyAddress
       }
 
       try {
@@ -97,6 +98,7 @@ export default defineComponent({
         const success = res.ok
         this.messageSentStatus = success ? 'send-successful' : 'send-failed'
       } catch (e) {
+        console.log("ERROR", e);
         this.messageSentStatus = 'send-failed'
       }
     },

--- a/src/plugins/message/components/MessageForm.vue
+++ b/src/plugins/message/components/MessageForm.vue
@@ -85,10 +85,11 @@ export default defineComponent({
         data,
         hash,
         sig,
+        address: signer.address
       }
 
       try {
-        const res = await fetch(`/sites_/[site]/message/sendMessag`, {
+        const res = await fetch(`/sites_/[site]/message/sendMessage`, {
           method: 'POST',
           body: JSON.stringify(body),
         })

--- a/src/plugins/message/components/MessageForm.vue
+++ b/src/plugins/message/components/MessageForm.vue
@@ -85,7 +85,7 @@ export default defineComponent({
         data,
         hash,
         sig,
-        address: signer.address
+        address: signer.address,
       }
 
       try {


### PR DESCRIPTION
#### Description of the change
Add membership check on the server side for NFT gateway contact form. The validation makes sure that the address being validated is the same as the one signing the message. After this validation is in place, we make sure that the address has the required membership, since any user can fake a signing message and directly make api request to the server to contact. Thus this check is necessary at the server to prevent the same.

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

- [x] Added check for signer at the server.
- [x] Added check for required membership at the server.

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.