### PR TITLE
feat: add popup from next button on get started page

### DIFF
--- a/src/components/GetStarted/GetStarted.vue
+++ b/src/components/GetStarted/GetStarted.vue
@@ -14,10 +14,10 @@ export default {
       this.socialMedia = socialMedia.toLowerCase()
     },
     openNiwa(link) {
-      console.log(link);
+      console.log(link)
       const popupLink = link + '?popup=true'
-      window.open(popupLink, 'Niwa', 'popup,width=500,height=700');
-    }
+      window.open(popupLink, 'Niwa', 'popup,width=500,height=700')
+    },
   },
   computed: {
     link() {
@@ -81,7 +81,10 @@ export default {
       </select>
     </section>
     <section class="mb-4">
-      <HSButton @click.prevent="openNiwa(link)" type="outlined" class="w-full gap-0.5 py-2 px-6"
+      <HSButton
+        @click.prevent="openNiwa(link)"
+        type="outlined"
+        class="w-full gap-0.5 py-2 px-6"
         >Next</HSButton
       >
     </section>

--- a/src/components/GetStarted/GetStarted.vue
+++ b/src/components/GetStarted/GetStarted.vue
@@ -13,6 +13,11 @@ export default {
     setSocialMedia(socialMedia) {
       this.socialMedia = socialMedia.toLowerCase()
     },
+    openNiwa(link) {
+      console.log(link);
+      const popupLink = link + '?popup=true'
+      window.open(popupLink, 'Niwa', 'popup,width=500,height=700');
+    }
   },
   computed: {
     link() {
@@ -76,7 +81,7 @@ export default {
       </select>
     </section>
     <section class="mb-4">
-      <HSButton :link="link" type="outlined" class="w-full gap-0.5 py-2 px-6"
+      <HSButton @click.prevent="openNiwa(link)" type="outlined" class="w-full gap-0.5 py-2 px-6"
         >Next</HSButton
       >
     </section>


### PR DESCRIPTION
#### Description of the change
When we go to the next step from the get started page, it opens a poup rather than redirecting to niwa.
<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
