### PR TITLE
feat: almost there section of the welcome flow

### DIFF
--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -4,6 +4,7 @@ import HSButton from '../Primitives/Hashi/HSButton.vue'
 import { GetModalProvider, ReConnectWallet } from '@fixtures/wallet'
 import { ClubsConfiguration, encode } from '@devprotocol/clubs-core'
 import { utils } from 'ethers'
+import { defaultPlugins } from '@constants/plugins'
 
 export default {
   name: 'AlmostThere',
@@ -18,7 +19,6 @@ export default {
         this.dbSetStatus = 'invalid-dao-name'
         return
       }
-
       const configuration: ClubsConfiguration = {
         name: this.daoName,
         twitterHandle: '',
@@ -27,9 +27,8 @@ export default {
         propertyAddress: this.address,
         adminRolePoints: 0,
         options: [],
-        plugins: [],
+        plugins: defaultPlugins,
       }
-
       const modalProvider = GetModalProvider()
       const { provider, currentAddress } = await ReConnectWallet(modalProvider)
       if (!currentAddress || !provider) {

--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -45,7 +45,11 @@ export default {
       }
 
       const body = {
-        site: this.daoName.toLowerCase(),
+        site: this.daoName
+          .toLowerCase()
+          .split(/[`!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~\s+]/)
+          .filter(i => i && i !== ' ')
+          .join('-'),
         config,
         hash,
         sig,
@@ -63,6 +67,11 @@ export default {
         this.dbSetStatus = 'successful'
       } else {
         this.dbSetStatus = 'failed'
+      }
+
+      if (isConfigSet) {
+        let host = window.location.host;
+        window.location.href = `https://${body.site}.${host}/setup/homepage`
       }
     },
   },

--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -33,7 +33,7 @@ export default {
       const modalProvider = GetModalProvider()
       const { provider, currentAddress } = await ReConnectWallet(modalProvider)
       if (!currentAddress || !provider) {
-        this.dbSetStatus = "wallet-not-connected"
+        this.dbSetStatus = 'wallet-not-connected'
         return
       }
       const signer = provider.getSigner()
@@ -129,7 +129,10 @@ export default {
           An error occured during setting your DAO.
         </h1>
       </div>
-      <div class="text-red-500" v-else-if="dbSetStatus == 'wallet-not-connected'">
+      <div
+        class="text-red-500"
+        v-else-if="dbSetStatus == 'wallet-not-connected'"
+      >
         <h1 class="font-title text-xl font-black">
           Connect your wallet before setting your DAO.
         </h1>

--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { Comment } from 'vue'
 import HSButton from '../Primitives/Hashi/HSButton.vue'
+import { ClubsConfiguration, encode } from '@devprotocol/clubs-core'
+import { utils } from 'ethers'
 
 export default {
   name: 'AlmostThere',
@@ -10,13 +12,52 @@ export default {
     dbSetStatus: '',
   }),
   methods: {
-    setDb() {
+    async setDb() {
       if (!this.daoName || this.daoName === '') {
         this.dbSetStatus = 'invalid-dao-name'
         return
       }
 
-      this.dbSetStatus = 'successful'
+      const configuration: ClubsConfiguration = {
+        name: this.daoName,
+        twitterHandle: '',
+        description: '',
+        url: '',
+        propertyAddress: this.address,
+        adminRolePoints: 0,
+        options: [],
+        plugins: [],
+      }
+
+      // TODO: use this
+      // const hash = await utils.hashMessage(configuration)
+      // const sig = await signer.signMessage(hash)
+      // if (!sig) {
+      //   return
+      // }
+
+      const body = {
+        site: this.daoName,
+        config: encode(configuration),
+        hash: null, // TODO: use this
+        sig: null, // TODO: use this
+        expectedAddress: null, // TODO: use this
+      }
+
+      // Save the config to db, this is the same as updateConfig in the admin sections.
+      // However just for now, wallet realted operations (like signing, hashing, validating sig) is disabled
+      // as we need to enable wallet connection if we do that.
+      const res = await fetch('/setConfig', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+
+      const isConfigSet = res.ok
+      if (isConfigSet) {
+        this.dbSetStatus = 'successful'
+      } else {
+        this.dbSetStatus = 'failed'
+      }
     },
   },
   computed: {

--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -48,7 +48,7 @@ export default {
         site: this.daoName
           .toLowerCase()
           .split(/[`!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~\s+]/)
-          .filter(i => i && i !== ' ')
+          .filter((i) => i && i !== ' ')
           .join('-'),
         config,
         hash,
@@ -70,7 +70,7 @@ export default {
       }
 
       if (isConfigSet) {
-        let host = window.location.host;
+        const host = window.location.host
         window.location.href = `https://${body.site}.${host}/setup/homepage`
       }
     },

--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -1,0 +1,94 @@
+<script lang="ts">
+import { Comment } from 'vue'
+import HSButton from '../Primitives/Hashi/HSButton.vue'
+
+export default {
+  name: 'AlmostThere',
+  components: { HSButton },
+  data: () => ({
+    daoName: '',
+    dbSetStatus: '',
+  }),
+  methods: {
+    setDb() {
+      if (!this.daoName || this.daoName === '') {
+        this.dbSetStatus = 'invalid-dao-name'
+        return
+      }
+
+      this.dbSetStatus = 'successful'
+    },
+  },
+  computed: {
+    network() {
+      const urlParams = new URLSearchParams(window.location.search)
+      return urlParams.get('network')
+    },
+    address() {
+      const urlParams = new URLSearchParams(window.location.search)
+      return urlParams.get('address')
+    },
+  },
+}
+</script>
+
+<template>
+  <div class="mt-[10%] flex flex-col items-center justify-items-center">
+    <section class="mb-16 mt-8">
+      <h1 class="mb-2 text-center font-title text-7xl font-bold">
+        Almost There
+      </h1>
+    </section>
+    <section class="mb-16">
+      <table class="table-auto py-4 px-6 text-xl">
+        <tr class="py-4 px-6 text-left">
+          <td class="py-4 px-6 text-left">Chain</td>
+          <td class="py-4 px-6 text-left">{{ network || '' }}</td>
+        </tr>
+        <tr class="py-4 px-6 text-left">
+          <td class="py-4 px-6 text-left">Token</td>
+          <td class="py-4 px-6 text-left">{{ address || '' }}</td>
+        </tr>
+        <tr class="py-4 px-6 text-left">
+          <td class="py-4 px-6 text-left">DAO name</td>
+          <td class="py-4 px-6 text-left">
+            <input
+              class="rounded bg-gray-700 px-8 py-4"
+              v-model="daoName"
+              id="fullname"
+              name="fullname"
+              placeholder="Enter your DAO name"
+              required
+            />
+          </td>
+        </tr>
+      </table>
+    </section>
+    <section class="mb-16" v-if="dbSetStatus !== ''">
+      <!-- Depending on access logic, show either one -->
+      <div v-if="dbSetStatus == 'successful'">
+        <h1 class="font-title text-xl font-black text-green-500">
+          Your DAO is setting up!
+        </h1>
+      </div>
+      <div class="text-red-500" v-else-if="dbSetStatus == 'invalid-dao-name'">
+        <h1 class="font-title text-xl font-black">
+          Enter valid DAO name, it cannot be empty
+        </h1>
+      </div>
+      <div class="text-red-500" v-else-if="dbSetStatus == 'failed'">
+        <h1 class="font-title text-xl font-black">
+          An error occured during setting your DAO.
+        </h1>
+      </div>
+    </section>
+    <section class="mb-4">
+      <HSButton
+        @click.prevent="setDb()"
+        type="outlined"
+        class="w-full gap-0.5 py-2 px-6"
+        >Next</HSButton
+      >
+    </section>
+  </div>
+</template>

--- a/src/components/AlmostThere/AlmostThere.vue
+++ b/src/components/AlmostThere/AlmostThere.vue
@@ -46,7 +46,7 @@ export default {
       }
 
       const body = {
-        site: this.daoName,
+        site: this.daoName.toLowerCase(),
         config,
         hash,
         sig,

--- a/src/constants/plugins.ts
+++ b/src/constants/plugins.ts
@@ -1,0 +1,54 @@
+import { ClubsPlugin } from '@devprotocol/clubs-core'
+
+export const defaultPlugins: ClubsPlugin[] = [
+  {
+    name: 'home',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'buy',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'fiat',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'join',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'me',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'members',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'nft',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'perks',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'quests',
+    enable: true,
+    options: [],
+  },
+  {
+    name: 'memberships',
+    enable: true,
+    options: [],
+  },
+]

--- a/src/layouts/Landing.astro
+++ b/src/layouts/Landing.astro
@@ -1,4 +1,6 @@
 ---
+import ConnectButton from '@components/Wallet/ConnectButton.vue'
+
 import '@styles/global.scss'
 const title = 'Clubs'
 const name = 'Clubs' // not sure the difference here compared to title
@@ -33,10 +35,10 @@ const twitterHandle = 'devprtcl'
   <body class="font-body bg-black text-white min-h-screen container mx-auto">
     <header class="flex justify-between py-4">
       <h1 class="text-xl font-bold">Clubs.xyz</h1>
-
-      <nav>
+      <nav class="gap-10 flex justify-between py-4">
         <!-- TODO: path for this -->
         <a class="border rounded py-2 px-4" href="/getstarted">Get Started</a>
+        <ConnectButton client:only="vue" />
       </nav>
     </header>
 

--- a/src/pages/almost-there.astro
+++ b/src/pages/almost-there.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '@layouts/Landing.astro'
+import AlmostThere from '@components/AlmostThere/AlmostThere.vue'
+---
+
+<Layout>
+  <AlmostThere client:only="vue" />
+</Layout>

--- a/src/pages/setConfig.ts
+++ b/src/pages/setConfig.ts
@@ -1,0 +1,57 @@
+import { authenticate } from '@devprotocol/clubs-core'
+import { providers } from 'ethers'
+import { createClient } from 'redis'
+
+export const post = async ({ request }: { request: Request }) => {
+  const { site, config, sig, hash } = (await request.json()) as {
+    site: string
+    config: string
+    hash: string
+    sig: string
+  }
+
+  // TODO: use this
+  // const provider = providers.getDefaultProvider(
+  //   import.meta.env.PUBLIC_WEB3_PROVIDER_URL
+  // )
+
+  const client = createClient({
+    url: process.env.REDIS_URL,
+    username: process.env.REDIS_USERNAME ?? '',
+    password: process.env.REDIS_PASSWORD ?? '',
+  })
+  await client.connect()
+
+  client.on('error', (e) => {
+    console.error('redis connection error: ', e)
+  })
+
+  // Unlike updateConfig, where previousConfiguration has to be there,
+  // here previousConfiguration should not be there.
+  const previousConfiguration = await client.get(site)
+  if (previousConfiguration) {
+    return new Response(JSON.stringify({ error: 'Config already found' }), {
+      status: 401,
+    })
+  }
+
+  // TODO: use this
+  // const authenticated = await authenticate({
+  //   message: hash,
+  //   signature: sig,
+  //   previousConfiguration,
+  //   provider,
+  // })
+  // TODO: use this
+  // if (!authenticated) {
+  //   return new Response(JSON.stringify({}), { status: 401 })
+  // }
+
+  try {
+    await client.set(site, config)
+    await client.quit()
+    return new Response(JSON.stringify({}), { status: 200 })
+  } catch (error) {
+    return new Response(JSON.stringify({ error }), { status: 500 })
+  }
+}

--- a/src/pages/setConfig.ts
+++ b/src/pages/setConfig.ts
@@ -1,14 +1,15 @@
-import { providers, utils} from 'ethers'
+import { providers, utils } from 'ethers'
 import { createClient } from 'redis'
 
 export const post = async ({ request }: { request: Request }) => {
-  const { site, config, sig, hash, expectedAddress } = (await request.json()) as {
-    site: string
-    config: string
-    hash: string
-    sig: string
-    expectedAddress: string
-  }
+  const { site, config, sig, hash, expectedAddress } =
+    (await request.json()) as {
+      site: string
+      config: string
+      hash: string
+      sig: string
+      expectedAddress: string
+    }
 
   const client = createClient({
     url: process.env.REDIS_URL,
@@ -32,7 +33,9 @@ export const post = async ({ request }: { request: Request }) => {
 
   const address = utils.recoverAddress(utils.hashMessage(hash), sig)
   if (address.toLowerCase() != expectedAddress.toLowerCase()) {
-    return new Response(JSON.stringify({error: "Invalid address"}), { status: 401 })
+    return new Response(JSON.stringify({ error: 'Invalid address' }), {
+      status: 401,
+    })
   }
 
   try {


### PR DESCRIPTION
#### Description of the change
Add in almost there page of the welcome flow. Here we ask the user for dao name and setup the db for that dao with empty/default values.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): In this section, while saving the dao using a post request, we need to somehow validate that it's coming from the frontend (that also from a user), otherwise the post request maybe vulnerable to ingestion(invalid data) or ddos attacks. I've commented the part where we can validate that as it requires wallet to be connected, but that can be added in after a discussion.
