### PR TITLE
adds "preview" banner when in draft mode

### DIFF
--- a/src/components/PreviewBanner/PreviewBanner.svelte
+++ b/src/components/PreviewBanner/PreviewBanner.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+</script>
+
+<div
+  class="fixed bottom-0 left-1 right-1 backdrop-blur-3xl rounded-t-3xl py-4 px-8 bg-black/50 z-50"
+>
+  <div class="flex items-center justify-center">
+    <span class="border rounded mr-4 py-1 px-4">Preview</span>
+
+    <span class="font-bold"
+      >Send blockchain transactions to complete process</span
+    >
+  </div>
+</div>

--- a/src/components/ProfileSetupForm/ProfileSetupForm.svelte
+++ b/src/components/ProfileSetupForm/ProfileSetupForm.svelte
@@ -43,7 +43,7 @@
     }
 
     const draftOptions =
-      config.options?.find((opt) => opt.key === '__draftOptions') ?? {}
+      config.options?.find((opt) => opt.key === '__draft') ?? {}
 
     const options = [
       {
@@ -51,7 +51,7 @@
         value: avatarPath ?? '',
       },
       {
-        key: '__draftOptions',
+        key: '__draft',
         value: Object.assign({}, draftOptions, { category: projectCategory }),
       },
     ]

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="fixed left-0 top-14 z-50 lg:sticky lg:left-auto lg:top-12">
+    <div class="fixed left-0 top-14 z-40 lg:sticky lg:left-auto lg:top-12">
       <button
         class="rounded-r-full bg-white px-0.5 py-1 text-black lg:hidden"
         @click="toggle"

--- a/src/components/WelcomeConnect/WelcomeConnect.svelte
+++ b/src/components/WelcomeConnect/WelcomeConnect.svelte
@@ -49,7 +49,7 @@
     }
 
     const updatedUptions = Object.assign({}, config.options, {
-      key: '__draftOptions',
+      key: '__draft',
       value: {
         isInDraft: true,
         address: currentAddress,

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -7,6 +7,7 @@ import Footer from '@components/Global/Footer.astro'
 import '@styles/global.scss'
 import { NavLink, PathCondition } from '@constants/navLink'
 import { UndefinedOr } from '@devprotocol/util-ts'
+import PreviewBanner from '@components/PreviewBanner/PreviewBanner.svelte'
 
 const { page } = Astro.params
 const { metaTitle, config } = Astro.props as {
@@ -102,6 +103,8 @@ const url = Astro.url.href.replace(/(.*)\/sites_\/\w*(.*)/i, '$1$2')
       isFullPageView ? (
         <main>
           <slot />
+
+          {isInDraft && <PreviewBanner />}
         </main>
       ) : (
         <>
@@ -120,6 +123,8 @@ const url = Astro.url.href.replace(/(.*)\/sites_\/\w*(.*)/i, '$1$2')
             </CLBWrapper>
           </main>
           <Footer />
+
+          {isInDraft && <PreviewBanner />}
         </>
       )
     }

--- a/src/pages/authenticating.astro
+++ b/src/pages/authenticating.astro
@@ -55,7 +55,7 @@ const config = Astro.props as ClubsConfiguration
         // If it is a new user, set the __draft user
         if (details?.isNewUser && uid) {
           const updatedUptions = Object.assign({}, config.options, {
-            key: '__draftOptions',
+            key: '__draft',
             value: {
               isInDraft: true,
               uid,


### PR DESCRIPTION
#### Description of the change

When in draft mode, the Default layout shows a "Preview Mode" banner

#### Screenshots
<img width="972" alt="Screenshot 2022-12-13 at 16 09 00" src="https://user-images.githubusercontent.com/11183054/207443955-75ff375b-0b2c-4c22-882f-1362a80bf9a4.png">

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
