### PR TITLE
Supports dynamic layout and theme

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,12 +25,7 @@ export default defineConfig({
       hooks: {
         'astro:server:setup': ({ server }) => {
           server.middlewares.use((req, _, next) => {
-            if (
-              req.headers.accept?.includes('text/html') ||
-              new URL(req.url, `http://${req.headers.host}`).pathname.includes(
-                '.'
-              ) === false
-            ) {
+            if (req.headers.accept?.includes('text/html')) {
               const host = req.headers.host.split('.')
 
               if (host.length > 1) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@astrojs/vercel": "2.3.6",
     "@astrojs/vue": "1.2.2",
     "@astropub/md": "^0.1.4",
-    "@devprotocol/clubs-core": "0.13.0-alpha.0",
+    "@devprotocol/clubs-core": "0.13.0-alpha.1",
     "@devprotocol/dev-kit": "6.10.0",
     "@devprotocol/elements": "0.2.2",
     "@devprotocol/hashi": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@astrojs/vercel": "2.3.6",
     "@astrojs/vue": "1.2.2",
     "@astropub/md": "^0.1.4",
-    "@devprotocol/clubs-core": "0.13.0-alpha.1",
+    "@devprotocol/clubs-core": "0.13.0",
     "@devprotocol/dev-kit": "6.10.0",
     "@devprotocol/elements": "0.2.2",
     "@devprotocol/hashi": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@astrojs/vercel": "2.3.6",
     "@astrojs/vue": "1.2.2",
     "@astropub/md": "^0.1.4",
-    "@devprotocol/clubs-core": "0.12.0",
+    "@devprotocol/clubs-core": "0.13.0-alpha.0",
     "@devprotocol/dev-kit": "6.10.0",
     "@devprotocol/elements": "0.2.2",
     "@devprotocol/hashi": "1.4.0",

--- a/scripts/populate.mjs
+++ b/scripts/populate.mjs
@@ -507,7 +507,7 @@ const populate = async () => {
             options: [],
           },
           {
-            name: 'home',
+            name: 'defaultTheme',
             enable: true,
             options: [
               {
@@ -645,6 +645,7 @@ const populate = async () => {
           },
         ],
         plugins: [
+          { name: 'defaultTheme', enable: true },
           {
             name: 'me',
             enable: true,
@@ -858,6 +859,7 @@ const populate = async () => {
           },
         ],
         plugins: [
+          { name: 'defaultTheme', enable: true },
           {
             name: 'me',
             enable: true,

--- a/src/pages/sites_/[site]/[...page].astro
+++ b/src/pages/sites_/[site]/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import { pageFactory } from '@devprotocol/clubs-core'
-import Layout from '@layouts/Default.astro'
 import { config as _config } from '@fixtures/config'
+import defaultTheme from '@plugins/default-theme'
 import buy from '@plugins/buy'
 import community from '@plugins/community'
 import fiat from '@plugins/fiat'
@@ -18,6 +18,7 @@ const { site, page } = Astro.params
 const { getStaticPaths, getCurrentConfig } = pageFactory({
   config: async () => await _config(site),
   plugins: {
+    defaultTheme,
     buy,
     community,
     fiat,
@@ -35,6 +36,7 @@ const path = (await getStaticPaths()).find(({ params }) => params.page === page)
 if (!path) {
   throw new Error('Path undefined: ', path)
 }
+const Layout = path.props.layout
 const Content = path.props.component
 const config = await getCurrentConfig()
 ---

--- a/src/pages/sites_/[site]/admin/[...page].astro
+++ b/src/pages/sites_/[site]/admin/[...page].astro
@@ -2,6 +2,7 @@
 import Admin from '@devprotocol/clubs-core/admin'
 import { adminFactory } from '@devprotocol/clubs-core'
 import { config as _config } from '@fixtures/config'
+import defaultTheme from '@plugins/default-theme'
 import admin from '@plugins/admin'
 import community from '@plugins/community'
 import memberships from '@plugins/memberships'
@@ -13,6 +14,7 @@ const { site, page } = Astro.params
 const { getStaticPaths } = adminFactory({
   config: async () => await _config(site),
   plugins: {
+    defaultTheme,
     admin,
     quests,
     community,

--- a/src/plugins/default-theme/index.ts
+++ b/src/plugins/default-theme/index.ts
@@ -1,0 +1,88 @@
+import type { Tiers } from '@constants/tier'
+import type { UndefinedOr } from '@devprotocol/util-ts'
+import {
+  ClubsFunctionGetAdminPaths,
+  ClubsFunctionGetLayout,
+  ClubsFunctionGetPagePaths,
+  ClubsFunctionThemePlugin,
+  ClubsPluginCategory,
+  ClubsThemePluginMeta,
+} from '@devprotocol/clubs-core'
+import { default as Layout } from '@layouts/Default.astro'
+import { default as Index } from '@plugins/home/index.astro'
+import { default as Admin } from '@plugins/home/admin.astro'
+import { HomeConfig } from '../../constants/homeConfig'
+import { NavLink } from '@constants/navLink'
+
+export const getPagePaths: ClubsFunctionGetPagePaths = async (
+  options,
+  { name, propertyAddress, rpcUrl, ...config }
+) => {
+  const tiers = options.find((opt) => opt.key === 'tiers')
+    ?.value as UndefinedOr<Tiers>
+
+  const homeConfig = options.find((opt) => opt.key === 'homeConfig')
+    ?.value as UndefinedOr<HomeConfig>
+
+  const sidebarPrimaryLinks =
+    config.options?.find((option) => option.key === 'sidebarPrimaryLinks')
+      ?.value ?? ([] as NavLink[])
+
+  const sidebarLinks =
+    config.options?.find((option) => option.key === 'sidebarLinks')?.value ??
+    ([] as NavLink[])
+
+  const avatarImgSrc = config.options?.find(
+    (option) => option.key === 'avatarImgSrc'
+  )?.value
+
+  return homeConfig
+    ? [
+        {
+          paths: [''],
+          component: Index,
+          props: {
+            name,
+            propertyAddress,
+            tiers,
+            homeConfig,
+            rpcUrl,
+            sidebarPrimaryLinks,
+            sidebarLinks,
+            avatarImgSrc,
+          },
+        },
+      ]
+    : []
+}
+
+export const getAdminPaths: ClubsFunctionGetAdminPaths = async (
+  options,
+  config
+) => [
+  {
+    paths: ['theme'],
+    component: Admin,
+    props: { options, config },
+  },
+]
+
+export const getLayout: ClubsFunctionGetLayout = async () => ({
+  layout: Layout,
+  props: {},
+})
+
+export const meta: ClubsThemePluginMeta = {
+  displayName: 'Default theme',
+  category: ClubsPluginCategory.Theme,
+  theme: {
+    previewImage: 'https://dummyimage.com/600x400/000/fff',
+  },
+}
+
+export default {
+  getPagePaths,
+  getAdminPaths,
+  getLayout,
+  meta,
+} as ClubsFunctionThemePlugin

--- a/src/plugins/home/index.ts
+++ b/src/plugins/home/index.ts
@@ -1,5 +1,3 @@
-import type { Tiers } from '@constants/tier'
-import type { UndefinedOr } from '@devprotocol/util-ts'
 import {
   ClubsFunctionGetAdminPaths,
   ClubsFunctionGetPagePaths,
@@ -7,58 +5,10 @@ import {
   ClubsPluginCategory,
   ClubsPluginMeta,
 } from '@devprotocol/clubs-core'
-import { default as Index } from './index.astro'
-import { default as Admin } from './admin.astro'
-import { HomeConfig } from '../../constants/homeConfig'
-import { NavLink } from '@constants/navLink'
 
-export const getPagePaths: ClubsFunctionGetPagePaths = async (
-  options,
-  { name, propertyAddress, rpcUrl, ...config }
-) => {
-  const tiers = options.find((opt) => opt.key === 'tiers')
-    ?.value as UndefinedOr<Tiers>
+export const getPagePaths: ClubsFunctionGetPagePaths = async () => [] // MOVE TO src/plugins/default-theme/index.ts
 
-  const homeConfig = options.find((opt) => opt.key === 'homeConfig')
-    ?.value as UndefinedOr<HomeConfig>
-
-  const sidebarPrimaryLinks =
-    config.options?.find((option) => option.key === 'sidebarPrimaryLinks')
-      ?.value ?? ([] as NavLink[])
-
-  const sidebarLinks =
-    config.options?.find((option) => option.key === 'sidebarLinks')?.value ??
-    ([] as NavLink[])
-
-  const avatarImgSrc = config.options?.find(
-    (option) => option.key === 'avatarImgSrc'
-  )?.value
-
-  return [
-    {
-      paths: [''],
-      component: Index,
-      props: {
-        name,
-        propertyAddress,
-        tiers,
-        homeConfig,
-        rpcUrl,
-        sidebarPrimaryLinks,
-        sidebarLinks,
-        avatarImgSrc,
-      },
-    },
-  ]
-}
-
-export const getAdminPaths: ClubsFunctionGetAdminPaths = async (options, _) => [
-  {
-    paths: ['home'],
-    component: Admin,
-    props: { options },
-  },
-]
+export const getAdminPaths: ClubsFunctionGetAdminPaths = async () => [] // MOVE TO src/plugins/default-theme/index.ts
 
 export const meta: ClubsPluginMeta = {
   displayName: 'Home',

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,10 +576,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@devprotocol/clubs-core@0.13.0-alpha.0":
-  version "0.13.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-0.13.0-alpha.0.tgz#fefec6b200e59f6181ac6be1002fb4bb87bc80bd"
-  integrity sha512-RGj9WO5O7p4yHx00XLI5LIRo8K8tpMJlmB02wmFSsutD6KEF3cdZspD7ssZ4gP+0Sfu7xpHW3ux0ohtTgtEj2g==
+"@devprotocol/clubs-core@0.13.0-alpha.1":
+  version "0.13.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-0.13.0-alpha.1.tgz#3d8bdfdf1353d49f1955a60a685fb0bacca44fbd"
+  integrity sha512-CdJpc1eno85atlDlcFw52PODXpD+1Gmy7KCT97T2LfgiXMU8AsoTX1XjZ51F3IBh7bXySr289/PNZuRNSc9wQA==
   dependencies:
     "@devprotocol/dev-kit" "6.10.0"
     "@devprotocol/elements" "0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,10 +576,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@devprotocol/clubs-core@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-0.12.0.tgz#fca67b9efd546dcafe4a1a5b4c49ec8c5f0f1df9"
-  integrity sha512-PCvFQIv4hZcT3fnUB5wHp4ZHlgYn08d0czsN2x9bcxCD47mfQZMpp47v4V5hnhzZV0ED6gh/3JRwo1pbuLMfqQ==
+"@devprotocol/clubs-core@0.13.0-alpha.0":
+  version "0.13.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-0.13.0-alpha.0.tgz#fefec6b200e59f6181ac6be1002fb4bb87bc80bd"
+  integrity sha512-RGj9WO5O7p4yHx00XLI5LIRo8K8tpMJlmB02wmFSsutD6KEF3cdZspD7ssZ4gP+0Sfu7xpHW3ux0ohtTgtEj2g==
   dependencies:
     "@devprotocol/dev-kit" "6.10.0"
     "@devprotocol/elements" "0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,10 +576,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@devprotocol/clubs-core@0.13.0-alpha.1":
-  version "0.13.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-0.13.0-alpha.1.tgz#3d8bdfdf1353d49f1955a60a685fb0bacca44fbd"
-  integrity sha512-CdJpc1eno85atlDlcFw52PODXpD+1Gmy7KCT97T2LfgiXMU8AsoTX1XjZ51F3IBh7bXySr289/PNZuRNSc9wQA==
+"@devprotocol/clubs-core@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-0.13.0.tgz#7ece361db29f993e192f824cfe1fd57d7fc25646"
+  integrity sha512-+l/56LkQ2Z9a2npzlCvW8YNKx/cfAOCWFcSRvoiKbkRkjNfc3RM2/3nfn7UzEJHz+sWZzzXhFeulcVqvIT9y7w==
   dependencies:
     "@devprotocol/dev-kit" "6.10.0"
     "@devprotocol/elements" "0.2.2"


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

- clubs-core v0.13.0 has been released with support for theme plugins in addition to standard plugins.
- The first theme plugin is implemented in src/plugins/default-theme.
- Theme plugins have new interfaces `getLayout`, and `meta.theme`.
- After clubs-core v0.13.0, standard plugins can also export layouts. If the item returned by `getPagePaths` has `layout`, the layout file will take precedence over the theme plugin.

#### Screenshots

![image](https://user-images.githubusercontent.com/1970283/209084937-7445fb22-1769-4dd3-868f-ac2e3f5f1aee.png)

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [X] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
