### PR TITLE
fix(integration): encode clubs config when using firebase authenticate

### DIFF
--- a/src/pages/authentication/[siteName].astro
+++ b/src/pages/authentication/[siteName].astro
@@ -29,7 +29,11 @@ const { siteName } = Astro.params
     signInWithEmailLink,
   } from 'firebase/auth'
   import { initializeFirebase } from '../../fixtures/firebase'
-  import { ClubsConfiguration, setConfig } from '@devprotocol/clubs-core'
+  import {
+    ClubsConfiguration,
+    encode,
+    setConfig,
+  } from '@devprotocol/clubs-core'
 
   import { defaultConfig } from '@constants/defaultConfig'
 
@@ -79,7 +83,7 @@ const { siteName } = Astro.params
 
           const body = {
             site,
-            config,
+            config: encode(config),
             uid,
           }
 


### PR DESCRIPTION
#### Description of the change
Add in the missing encode() from clubs-core on configuration when using authentication using firebase.


#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.