### PR TITLE
feat(integration): add next button in the setup flow core pages

### DIFF
--- a/src/pages/[site]/setup/design.astro
+++ b/src/pages/[site]/setup/design.astro
@@ -4,6 +4,7 @@ import { config as _config } from '@fixtures/config'
 import { adminFactory } from '@devprotocol/clubs-core'
 import defaultTheme from '@plugins/default-theme'
 import SetupLayout from '@layouts/Setup.astro'
+import NextButton from '@components/Setup/NextButton.astro'
 
 const { site, page } = Astro.params
 
@@ -35,5 +36,10 @@ const homeConfig = path?.props.options.find(
     client:load
     homeConfig={homeConfig.value}
     currentPluginIndex={path?.props.clubs.currentPluginIndex}
+  />
+
+  <NextButton
+    next={`/${site}/setup/memberships`}
+    slot="aside:after-built-in-buttons"
   />
 </SetupLayout>

--- a/src/pages/[site]/setup/memberships.astro
+++ b/src/pages/[site]/setup/memberships.astro
@@ -4,6 +4,7 @@ import { config as _config } from '@fixtures/config'
 import { adminFactory } from '@devprotocol/clubs-core'
 import memberships, { Membership } from '@plugins/memberships'
 import SetupLayout from '@layouts/Setup.astro'
+import NextButton from '@components/Setup/NextButton.astro'
 
 const { site } = Astro.params
 
@@ -59,6 +60,11 @@ const clubs = path.props.clubs
       )
     }
   </section>
+
+  <NextButton
+    next={`/${site}/setup/preview`}
+    slot="aside:after-built-in-buttons"
+  />
 </SetupLayout>
 
 <script>

--- a/src/pages/[site]/setup/preview.astro
+++ b/src/pages/[site]/setup/preview.astro
@@ -5,6 +5,7 @@ import { adminFactory } from '@devprotocol/clubs-core'
 import admin from '@plugins/admin'
 import SetupLayout from '@layouts/Setup.astro'
 import image from '@assets/preview-overview-chart.png'
+import NextButton from '@components/Setup/NextButton.astro'
 
 const { site } = Astro.params
 
@@ -68,4 +69,9 @@ const baseUrl = ((url) => `${url.protocol}//${site}.${url.host}/`)(
       </div>
     </a>
   </section>
+
+  <NextButton
+    next={`/${site}/setup/publish`}
+    slot="aside:after-built-in-buttons"
+  />
 </SetupLayout>

--- a/src/pages/[site]/setup/publish.astro
+++ b/src/pages/[site]/setup/publish.astro
@@ -10,6 +10,7 @@ import PublishConnect from '@components/PublishConnect/PublishConnect.vue'
 import PublishNetworkSelection from '@components/PublishNetworkSelection/PublishNetworkSelection.vue'
 import { UndefinedOr } from '@devprotocol/util-ts'
 import { DraftOptions } from '@constants/draft'
+import NextButton from '@components/Setup/NextButton.astro'
 
 const { site } = Astro.params
 
@@ -65,4 +66,12 @@ const membershipsPluginOptions = membershipsPlugin?.options?.find(
       <PublishGrants />
     </a>
   </section>
+
+  <NextButton
+    next={(window.location.href = new URL(
+      '/admin/overview',
+      `${location.protocol}//${site}.${location.host}`
+    ).toString())}
+    slot="aside:after-built-in-buttons"
+  />
 </SetupLayout>


### PR DESCRIPTION
#### Description of the change
Add next button, that redirects to the next setup step in major setup stages.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
