### PR TITLE
fix(bugs): discord auth & double submit config interaction.

### DIFF
--- a/src/components/PublishNetworkSelection/PublishNetworkSelection.vue
+++ b/src/components/PublishNetworkSelection/PublishNetworkSelection.vue
@@ -351,11 +351,19 @@ export default defineComponent({
         ? classes + ' line-through opacity-50'
         : classes
     },
+    baseTokenizationLink() {
+      return `https://niwa.xyz/tokenize/${this.category?.toLowerCase()}`
+    },
     link() {
-      return `https://${this.networkSelected.toLowerCase()}.niwa.xyz/tokenize/${this.category?.toLowerCase()}`
+      const url = new URL(this.baseTokenizationLink)
+      url.host = `${this.networkSelected.toLowerCase()}.${url.host}`
+      return url
     },
     linkOrigin() {
       return new URL(this.link).origin
+    },
+    baseTokenizationLinkOrigin() {
+      return new URL(this.baseTokenizationLink).origin
     },
     step3Enabled() {
       return (
@@ -460,7 +468,11 @@ export default defineComponent({
     },
 
     listenForAddress(event: MessageEvent<any>) {
-      if (event.origin !== this.linkOrigin) return
+      if (
+        event.origin !== this.linkOrigin &&
+        event.origin !== this.baseTokenizationLinkOrigin
+      )
+        return
       const { address } = event.data
       if (!address) return
       this.addressFromNiwa = address

--- a/src/layouts/BaseClubs.astro
+++ b/src/layouts/BaseClubs.astro
@@ -1,0 +1,71 @@
+---
+import ClubsColor from '@assets/clubs--color.svg'
+import VercelAnalytics from '@components/Analytics/VercelAnalytics.astro'
+import ConnectButton from '@components/Wallet/ConnectButton.vue'
+
+import '@devprotocol/clubs-core/styles'
+
+const { connectButton = 'hidden' } = Astro.props as {
+  connectButton?: 'show' | 'hidden'
+}
+
+const title = 'Clubs'
+const name = 'Clubs' // not sure the difference here compared to title
+const description = ''
+const url = ''
+const ogURL = ''
+const twitterHandle = 'devprtcl'
+---
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+    <link rel="icon" type="image/svg" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin /><link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <meta name="description" content={`${description}`} />
+    <meta property="og:title" content={title} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={url} />
+    <meta property="og:image" content={`${ogURL}`} />
+    <meta property="og:description" content={description} />
+    <meta property="og:site_name" content={name} />
+    <meta name="twitter:site" content={twitterHandle} />
+    <meta name="twitter:creator" content={twitterHandle} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={`${ogURL}`} />
+  </head>
+
+  <body class="min-h-screen bg-dp-black-600 font-body text-white">
+    <slot name="before-header" />
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a href="/">
+        <h1
+          class="flex items-center gap-2.5 font-['Poppins'] text-xl font-bold"
+        >
+          <img src={ClubsColor} />Clubs
+        </h1>
+      </a>
+      <slot name="right" />
+      {
+        connectButton === 'show' && (
+          <nav class="flex justify-between gap-10">
+            <ConnectButton type="white" client:load />
+          </nav>
+        )
+      }
+    </header>
+
+    <main>
+      <slot />
+    </main>
+    <VercelAnalytics />
+  </body>
+</html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,5 @@
 ---
-import Layout from '@layouts/Landing.astro'
+import Layout from '@layouts/BaseClubs.astro'
 
 const { redirectionCtaText, redirectionCtaUrl } = Astro.props
 


### PR DESCRIPTION
#### Description of the change
Fix discord auth bug in niwa. Update the check for listenAddress to now consider both subdomain(network) as well as the base domain for validity. 

I also had to create a seperate base layout to be used in 404 page- this is because, using the landing layout caused 2 layouts with onSubmitConfig in the setup pages. Hence because of this 2 request for wallet signature confirmations were being made where one resulted in error and caused bad ux.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
