### PR TITLE
fix(server): add reconnect startegy and keep alive strategy on redis client

### DIFF
--- a/src/fixtures/config.ts
+++ b/src/fixtures/config.ts
@@ -8,6 +8,10 @@ export const config = async (
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',
     password: process.env.REDIS_PASSWORD ?? '',
+    socket: {
+      keepAlive: 1,
+      reconnectStrategy: 1,
+    },
   })
   await client.connect()
 

--- a/src/pages/api/addDaoToDraft.ts
+++ b/src/pages/api/addDaoToDraft.ts
@@ -29,6 +29,10 @@ export const post = async ({ request }: { request: Request }) => {
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',
     password: process.env.REDIS_PASSWORD ?? '',
+    socket: {
+      keepAlive: 1,
+      reconnectStrategy: 1,
+    },
   })
   await client.connect()
 

--- a/src/pages/api/fetchClubs.ts
+++ b/src/pages/api/fetchClubs.ts
@@ -25,6 +25,10 @@ export const post = async ({ request }: { request: Request }) => {
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',
     password: process.env.REDIS_PASSWORD ?? '',
+    socket: {
+      keepAlive: 1,
+      reconnectStrategy: 1,
+    },
   })
   await client.connect()
 

--- a/src/pages/api/updateConfig.ts
+++ b/src/pages/api/updateConfig.ts
@@ -14,6 +14,10 @@ export const post = async ({ request }: { request: Request }) => {
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',
     password: process.env.REDIS_PASSWORD ?? '',
+    socket: {
+      keepAlive: 1,
+      reconnectStrategy: 1,
+    },
   })
   await client.connect()
 

--- a/src/pages/api/updateDraftConfig.ts
+++ b/src/pages/api/updateDraftConfig.ts
@@ -25,6 +25,10 @@ export const post = async ({ request }: { request: Request }) => {
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',
     password: process.env.REDIS_PASSWORD ?? '',
+    socket: {
+      keepAlive: 1,
+      reconnectStrategy: 1,
+    },
   })
   await client.connect()
 

--- a/src/pages/api/verifySiteName/[...site].ts
+++ b/src/pages/api/verifySiteName/[...site].ts
@@ -23,6 +23,10 @@ export const get = async ({
           url: process.env.REDIS_URL,
           username: process.env.REDIS_USERNAME ?? '',
           password: process.env.REDIS_PASSWORD ?? '',
+          socket: {
+            keepAlive: 1,
+            reconnectStrategy: 1,
+          },
         })
       : undefined
   await client?.connect()

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -45,6 +45,10 @@ export const post = async ({ request }: { request: Request }) => {
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',
     password: process.env.REDIS_PASSWORD ?? '',
+    socket: {
+      keepAlive: 1,
+      reconnectStrategy: 1,
+    },
   })
   await client.connect()
 


### PR DESCRIPTION
#### Description of the change
This change adds a reconnect startegy and a keep alive startegy while creating redis client instances. This is set to a small number 1 (1 miliseconds). This will enable to keep alive or reconnect the client to the server in case the clients get disconnected unintentionally.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
