### PR TITLE
reverts auth after changing backend

### DIFF
--- a/src/components/EmailConnect/EmailConnect.svelte
+++ b/src/components/EmailConnect/EmailConnect.svelte
@@ -26,6 +26,10 @@
         : JSON.stringify({ email }),
     })
       .then(() => {
+        // The link was successfully sent. Inform the user.
+        // Save the email locally so you don't need to ask the user for it again
+        // if they open the link on the same device.
+        window.localStorage.setItem('emailForSignIn', email)
         emailSent = true
       })
       .catch((err) => {

--- a/src/pages/authentication/[siteName].astro
+++ b/src/pages/authentication/[siteName].astro
@@ -35,59 +35,71 @@ const { siteName } = Astro.params
 
   import type { DraftOptions } from '@constants/draft'
 
+  import { isSignInWithEmailLink, signInWithEmailLink } from 'firebase/auth'
+
   // Confirm the link is a sign-in with email link.
   const auth = instanceStore.initializedApp
   const siteName = (document.getElementById('siteName') as HTMLInputElement)
     ?.value as string
 
-  auth.onIdTokenChanged(async (user) => {
-    console.log('auth.onIdTokenChanged', { user })
-    if (!user) {
-      return
+  if (isSignInWithEmailLink(auth, window.location.href)) {
+    let email = window.localStorage.getItem('emailForSignIn')
+    if (!email) {
+      // User opened the link on a different device. To prevent session fixation
+      // attacks, ask the user to provide the associated email again. For example:
+      email = window.prompt('Please provide your email for confirmation')
     }
 
-    const jwtToken = await user.getIdToken()
-    const site: string | undefined =
-      window.location.pathname.split('/').pop() || siteName
-
-    const config: ClubsConfiguration = {
-      ...defaultConfig,
-      name: site,
-      url: `https://${siteName}.clubs.place`,
-      options: [
-        ...(defaultConfig.options ? defaultConfig.options : []),
-        {
-          key: '__draft',
-          value: {
-            isInDraft: true,
-            uid: user.uid,
-          },
-        } as DraftOptions,
-      ],
-    }
-
-    const body = {
-      site,
-      config: encode(config),
-      uid: user.uid,
-    }
-
-    // Save the config to db.
-    const res = await fetch('/api/addDaoToDraft', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${jwtToken}`,
-      },
-      body: JSON.stringify(body),
-    })
-
-    if (res.ok) {
-      setConfig(config)
-      window.location.href = new URL(
-        `${siteName}/setup/basic`,
-        `${location.protocol}//${location.host}`
-      ).toString()
-    }
-  })
+    signInWithEmailLink(auth, email ?? '', window.location.href)
+      .then(async (result) => {
+        // Clear email from storage.
+        window.localStorage.removeItem('emailForSignIn')
+        const jwtToken = await result.user.getIdToken()
+        const site: string | undefined =
+          window.location.pathname.split('/').pop() || siteName
+        const uid = result.user.uid
+        // If it is a new user, set the __draft user
+        if (uid) {
+          // Make the default config.
+          const config: ClubsConfiguration = {
+            ...defaultConfig,
+            name: site,
+            options: [
+              ...(defaultConfig.options ? defaultConfig.options : []),
+              {
+                key: '__draft',
+                value: {
+                  isInDraft: true,
+                  uid: uid,
+                },
+              } as DraftOptions,
+            ],
+          }
+          const body = {
+            site,
+            config: encode(config),
+            uid,
+          }
+          // Save the config to db.
+          const res = await fetch('/api/addDaoToDraft', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${jwtToken}`,
+            },
+            body: JSON.stringify(body),
+          })
+          if (res.ok) {
+            setConfig(config)
+            window.location.href = new URL(
+              `${siteName}/setup/basic`,
+              `${location.protocol}//${location.host}`
+            ).toString()
+          }
+        }
+      })
+      .catch((err) => {
+        console.error('error using signInWithEmailLink: ', err)
+      })
+  }
 </script>

--- a/src/pages/authentication/index.astro
+++ b/src/pages/authentication/index.astro
@@ -21,16 +21,33 @@ import Layout from '@layouts/Landing.astro'
 </Layout>
 
 <script>
+  import { isSignInWithEmailLink, signInWithEmailLink } from 'firebase/auth'
   import { instanceStore } from '../../fixtures/firebase/clientInstance'
 
   const auth = instanceStore.initializedApp
 
-  auth.onIdTokenChanged((user) => {
-    if (user && user.uid) {
-      window.location.href = new URL(
-        `/user/${user.uid}`,
-        `${location.protocol}//${location.host}`
-      ).toString()
+  if (isSignInWithEmailLink(auth, window.location.href)) {
+    let email = window.localStorage.getItem('emailForSignIn')
+    if (!email) {
+      // User opened the link on a different device. To prevent session fixation
+      // attacks, ask the user to provide the associated email again. For example:
+      email = window.prompt('Please provide your email for confirmation')
     }
-  })
+
+    signInWithEmailLink(auth, email ?? '', window.location.href)
+      .then(async (result) => {
+        // Clear email from storage.
+        window.localStorage.removeItem('emailForSignIn')
+
+        const uid = result.user.uid
+
+        window.location.href = new URL(
+          `/user/${uid}`,
+          `${location.protocol}//${location.host}`
+        ).toString()
+      })
+      .catch((err) => {
+        console.error('error using signInWithEmailLink: ', err)
+      })
+  }
 </script>


### PR DESCRIPTION
#### Description of the change

The backend method to create a link was changed. This broke the updated frontend way we authenticate with Firebase. Reverts to the older way, which works with the updated backend code.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
