### PR TITLE
reduce `await`

### DIFF
--- a/src/pages/sites_/[site]/[...page].astro
+++ b/src/pages/sites_/[site]/[...page].astro
@@ -18,8 +18,10 @@ import memberships from '@plugins/memberships'
 import PageNotFound from '@pages/404.astro'
 
 const { site, page } = Astro.params
-const { getStaticPaths, getCurrentConfig } = pageFactory({
-  config: async () => await _config(site),
+const config = await _config(site)
+
+const { getStaticPaths } = pageFactory({
+  config: () => Promise.resolve(config),
   plugins: {
     defaultTheme,
     buy,
@@ -37,7 +39,6 @@ const { getStaticPaths, getCurrentConfig } = pageFactory({
   },
 })
 const path = (await getStaticPaths()).find(({ params }) => params.page === page)
-const config = await getCurrentConfig()
 
 const Layout = path?.props.layout
 const Content = path?.props.component


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->
- `getCurrentConfig` increases the number of potential DB connections and increases the waiting time.
- In server builds we can use predefined variables in the `getStaticPath` factory (in static builds, `getStaticPath` uses a limited scope), so precomputing `getCurrentConfig` eliminates the extra awaiting.

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
