### PR TITLE
fix(integration): add value from event in quests admin page

### DIFF
--- a/src/plugins/quests/components/AdminQuestsForm.vue
+++ b/src/plugins/quests/components/AdminQuestsForm.vue
@@ -14,9 +14,14 @@ export default defineComponent({
     },
   },
   methods: {
-    updateOptions() {
+    updateOptions(event: Event) {
       setOptions(
-        [{ key: 'deworkUrl', value: this.deworkUrl }],
+        [
+          {
+            key: 'deworkUrl',
+            value: (event.target as HTMLInputElement)?.value || this.deworkUrl,
+          },
+        ],
         this.currentPluginIndex
       )
     },


### PR DESCRIPTION
#### Description of the change
This change adds in a fallback value (which is taken from config itself) and the main value is computed using input event value in the quests admin plugins.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
