### PR TITLE
fix: default plugin enable status on admin/plugins

### DIFF
--- a/src/components/AdminPlugins/AdminPlugins.jsx
+++ b/src/components/AdminPlugins/AdminPlugins.jsx
@@ -4,11 +4,45 @@ import { decode, setConfig } from '@devprotocol/clubs-core'
 class AdminPlugins extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { config: decode(props.encodedConfig) }
+
+    let decodedConfig = decode(props.clubs.encodedClubsConfiguration)
+    const injectedPlugins = props.clubs.plugins
+
+    console.log("Decoded config", decodedConfig.plugins)
+
+    const plugins = []
+    let adminPlugin = {}
+    for (const plugin of decodedConfig.plugins) {
+      // Skip the admin plugin, but maintain a backup to add it later while doing setConfig in order to
+      // avoid overriding it.
+      if (plugin.name.toLowerCase() === 'admin') {
+        adminPlugin = plugin
+        continue
+      }
+
+      // Find how many plugisn match the same name and are enabled.
+      const matchingInjectedPlugins = injectedPlugins.filter(
+        (iP) => iP.name.toLowerCase() === plugin.name.toLowerCase() && iP.enable
+      )
+      plugins.push({
+        ...plugin,
+        enable: matchingInjectedPlugins.length > 0 || plugin.enable, // If length is 0, that means plugins doesn't exist or is not enabled in injection so we keep it's status as is.
+      })
+    }
+
+    decodedConfig = {
+      ...decodedConfig,
+      plugins, // NOTE: this doesn't contain the 'admin' plugin, it has to be added back in when we are update the config in the db.
+    }
+
+    this.state = { config: decodedConfig, adminPlugin }
     this.toggleActivation = this.toggleActivation.bind(this)
   }
 
   toggleActivation = (pluginName) => {
+    // Fail safe to avoid toggling admin plugin
+    if (pluginName.toLowerCase() === 'admin') return
+
     this.setState((prevState) => {
       const plugins = prevState.config.plugins
 
@@ -23,7 +57,10 @@ class AdminPlugins extends React.Component {
       // 4. Update the toggle w.r.t all plugins.
       plugins[index] = pluginDetails
       // 5. Update the config.
-      const config = { ...prevState.config, plugins }
+      const config = {
+        ...prevState.config,
+        plugins: [...plugins, prevState.adminPlugin], // HERE: we have added back the admin plugin in the config.
+      }
       // 6. Set config.
       setConfig(config)
       // 7. Update component state.
@@ -43,7 +80,10 @@ class AdminPlugins extends React.Component {
           Plugins
         </p>
         {this.state.config.plugins.map((plugin, i) => (
-          <div className="flex w-full flex-row items-center justify-between gap-[10px] p-0">
+          <div
+            className="flex w-full flex-row items-center justify-between gap-[10px] p-0"
+            key={i}
+          >
             <p className="h-[24px] font-body text-base font-normal capitalize leading-6">
               {plugin.name}
             </p>

--- a/src/components/AdminPlugins/AdminPlugins.jsx
+++ b/src/components/AdminPlugins/AdminPlugins.jsx
@@ -8,8 +8,6 @@ class AdminPlugins extends React.Component {
     let decodedConfig = decode(props.clubs.encodedClubsConfiguration)
     const injectedPlugins = props.clubs.plugins
 
-    console.log("Decoded config", decodedConfig.plugins)
-
     const plugins = []
     let adminPlugin = {}
     for (const plugin of decodedConfig.plugins) {

--- a/src/plugins/admin/plugins.astro
+++ b/src/plugins/admin/plugins.astro
@@ -4,7 +4,4 @@ import AdminPlugins from '@components/AdminPlugins/AdminPlugins.jsx'
 const { clubs } = Astro.props
 ---
 
-<AdminPlugins
-  client:only="react"
-  encodedConfig={clubs.encodedClubsConfiguration}
-/>
+<AdminPlugins client:only="react" clubs={clubs} />


### PR DESCRIPTION
#### Description of the change
This change attempts to fix the default plugin enable status on the 'admin/plugins' page and also hides the 'admin' plugin to disallow users from disabling it. The 'admin' plugin is removed from the list of plugins before displaying it and then added back in while updating config in the db to achieve preventing users to disable admin plugin.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): Another approach to hide the 'admin' plugin could be to keep it in the array and just use css to hide that input field.
