### PR TITLE
Revert "fix(integration): fix next button slot in setup flow"

### DIFF
--- a/src/pages/[site]/setup/basic.astro
+++ b/src/pages/[site]/setup/basic.astro
@@ -35,7 +35,7 @@ const siteBaseUrl = ((url) => `${url.protocol}//${site}.${url.host}/`)(
       <ProfileSetupForm client:load config={config} />
       <NextButton
         next={`/${site}/setup/design`}
-        slot="aside:after-built-in-buttons"
+        slot="admin:aside:after-built-in-buttons"
       />
     </SetupLayout>
   ) : (

--- a/src/pages/[site]/setup/design.astro
+++ b/src/pages/[site]/setup/design.astro
@@ -47,7 +47,7 @@ const siteBaseUrl = ((url) =>
 
       <NextButton
         next={`/${site}/setup/memberships`}
-        slot="aside:after-built-in-buttons"
+        slot="admin:aside:after-built-in-buttons"
       />
     </SetupLayout>
   ) : (

--- a/src/pages/[site]/setup/memberships.astro
+++ b/src/pages/[site]/setup/memberships.astro
@@ -76,7 +76,7 @@ const clubs = path?.props.clubs
 
       <NextButton
         next={`/${site}/setup/preview`}
-        slot="aside:after-built-in-buttons"
+        slot="admin:aside:after-built-in-buttons"
       />
     </SetupLayout>
   ) : (

--- a/src/pages/[site]/setup/preview.astro
+++ b/src/pages/[site]/setup/preview.astro
@@ -79,7 +79,7 @@ const siteBaseUrl = ((url) =>
 
       <NextButton
         next={`/${site}/setup/publish`}
-        slot="aside:after-built-in-buttons"
+        slot="admin:aside:after-built-in-buttons"
       />
     </SetupLayout>
   ) : (


### PR DESCRIPTION
Reverts dev-protocol/clubsx#640

@yashdesu Sorry, I was a bit mistaken. As you can see with the following code, the latest clubs-core has updated the slot names, so I think we need to revert this PR.

https://github.com/dev-protocol/clubs-core/blob/f023935ab5e227e9b3199cca9e54e8399b2b8694/src/layouts/Admin.astro#L63

https://github.com/dev-protocol/clubs-core/blob/f023935ab5e227e9b3199cca9e54e8399b2b8694/src/layouts/Admin.astro#L101