### PR TITLE
fix: /api/encrypt api failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "firebase": "^9.14.0",
     "firebase-admin": "^11.3.0",
     "jsonwebtoken": "^9.0.0",
-    "jsonwebtoken-esm": "^2.0.1",
     "marked": "4.3.0",
     "postcss": "8.4.21",
     "ramda": "0.28.0",

--- a/src/pages/api/decrypt.ts
+++ b/src/pages/api/decrypt.ts
@@ -1,6 +1,6 @@
 import { authenticate, decode } from '@devprotocol/clubs-core'
 import { providers } from 'ethers'
-import { verify } from 'jsonwebtoken-esm'
+import { verify } from 'jsonwebtoken'
 import { createClient } from 'redis'
 
 export const post = async ({ request }: { request: Request }) => {

--- a/src/pages/api/decrypt.ts
+++ b/src/pages/api/decrypt.ts
@@ -1,6 +1,6 @@
 import { authenticate, decode } from '@devprotocol/clubs-core'
 import { providers } from 'ethers'
-import { verify } from 'jsonwebtoken'
+import jsonwebtoken from 'jsonwebtoken'
 import { createClient } from 'redis'
 
 export const post = async ({ request }: { request: Request }) => {
@@ -54,7 +54,7 @@ export const post = async ({ request }: { request: Request }) => {
     return new Response(JSON.stringify({}), { status: 401 })
   }
 
-  let decoded = verify(encryptedText, process.env.SALT ?? '')
+  let decoded = jsonwebtoken.verify(encryptedText, process.env.SALT ?? '')
 
   return new Response(
     JSON.stringify({

--- a/src/pages/api/encrypt.ts
+++ b/src/pages/api/encrypt.ts
@@ -1,11 +1,11 @@
-import { sign } from 'jsonwebtoken'
+import jsonwebtoken from 'jsonwebtoken'
 
 export const post = async ({ request }: { request: Request }) => {
   const { text } = (await request.json()) as {
     text: string
   }
 
-  const encrypted = sign(text, process.env.SALT ?? '')
+  const encrypted = jsonwebtoken.sign(text, process.env.SALT ?? '')
 
   return new Response(JSON.stringify({ encrypted }), { status: 200 })
 }

--- a/src/pages/api/encrypt.ts
+++ b/src/pages/api/encrypt.ts
@@ -1,4 +1,4 @@
-import { sign } from 'jsonwebtoken-esm'
+import { sign } from 'jsonwebtoken'
 
 export const post = async ({ request }: { request: Request }) => {
   const { text } = (await request.json()) as {

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -76,7 +76,10 @@ export const post = async ({ request }: { request: Request }) => {
     })
   }
 
-  let decodedEmail = jsonwebtoken.(formData.destinationEmail, process.env.SALT ?? '')
+  let decodedEmail = jsonwebtoken.verify(
+    formData.destinationEmail,
+    process.env.SALT ?? ''
+  )
 
   const membershipsData = configuration.plugins?.[
     membershipPluginIndex ?? 0

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -6,7 +6,7 @@ import type { UndefinedOr } from '@devprotocol/util-ts'
 import type { GatedMessage } from '@plugins/message/types'
 import type { Membership } from '@plugins/memberships'
 import sgMail from '@sendgrid/mail'
-import { verify } from 'jsonwebtoken-esm'
+import { verify } from 'jsonwebtoken'
 
 export const post = async ({ request }: { request: Request }) => {
   const {

--- a/src/pages/sites_/[site]/message/sendMessage.ts
+++ b/src/pages/sites_/[site]/message/sendMessage.ts
@@ -6,7 +6,7 @@ import type { UndefinedOr } from '@devprotocol/util-ts'
 import type { GatedMessage } from '@plugins/message/types'
 import type { Membership } from '@plugins/memberships'
 import sgMail from '@sendgrid/mail'
-import { verify } from 'jsonwebtoken'
+import jsonwebtoken from 'jsonwebtoken'
 
 export const post = async ({ request }: { request: Request }) => {
   const {
@@ -76,7 +76,7 @@ export const post = async ({ request }: { request: Request }) => {
     })
   }
 
-  let decodedEmail = verify(formData.destinationEmail, process.env.SALT ?? '')
+  let decodedEmail = jsonwebtoken.(formData.destinationEmail, process.env.SALT ?? '')
 
   const membershipsData = configuration.plugins?.[
     membershipPluginIndex ?? 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4759,11 +4759,6 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonwebtoken-esm@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken-esm/-/jsonwebtoken-esm-2.0.1.tgz#e5f95d7d8849ee7cb183f793671c3e242783aa36"
-  integrity sha512-uZwq66J1WgwevzBheW8AMj8STn9QLXHLtY5cI52ztzip8VFPwoqaz/RQmgfNMivt+yD2Lfi4YS4uYHoKz0Fw9g==
-
 jsonwebtoken@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"


### PR DESCRIPTION
#### Description of the change
Revert the code to using `use jsonwebtoken instead of jsonwebtoken-esm` for encrypting and decrypting data.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
