### PR TITLE
Supports PageContentHomeBeforeContent slots in the default theme

### DIFF
--- a/src/plugins/default-theme/pages/index.astro
+++ b/src/plugins/default-theme/pages/index.astro
@@ -2,18 +2,24 @@
 import Markdown from '@components/Markdown/Markdown.astro'
 import Memberships from '../components/Memberships/Memberships.astro'
 import type { Membership } from '@plugins/memberships'
+import { ClubsSlotName, type ClubsPropsPages } from '@devprotocol/clubs-core'
 
-const { memberships, homeConfig, name } = Astro.props as {
-  memberships?: Membership[]
-  homeConfig: {
-    hero: {
-      image: string
+const { memberships, homeConfig, name, clubs } =
+  Astro.props as ClubsPropsPages & {
+    memberships?: Membership[]
+    homeConfig: {
+      hero: {
+        image: string
+      }
+      description: string
+      body: string
     }
-    description: string
-    body: string
+    name: string
   }
-  name: string
-}
+
+const SlotsPageContentHomeBeforeContent = clubs.slots.filter(({ slot }) => {
+  return slot === ClubsSlotName.PageContentHomeBeforeContent
+})
 ---
 
 <article class="grid gap-6">
@@ -35,6 +41,13 @@ const { memberships, homeConfig, name } = Astro.props as {
       )
     }
   </section>
+
+  {
+    // Display slots of PageContentHomeBeforeContent
+    SlotsPageContentHomeBeforeContent.map((Slot) => (
+      <Slot.component {...Slot.props} />
+    ))
+  }
 
   <h2 class="text-center text-xl font-bold lg:text-4xl">About {name}</h2>
   <Markdown


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->
- Supports PageContentHomeBeforeContent slots in the default theme

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
