### PR TITLE
Implement feature flags

### DIFF
--- a/src/fixtures/flags/index.ts
+++ b/src/fixtures/flags/index.ts
@@ -1,0 +1,32 @@
+import { whenDefined, type UndefinedOr } from '@devprotocol/util-ts'
+
+export enum FeatureFlags {
+  StoresOnMarketplace = 'stores-on-marketplace',
+}
+export enum FeatureFlagValues {
+  Enable = 'enable',
+}
+export const flags: Map<FeatureFlags, FeatureFlagValues[]> = new Map([
+  [FeatureFlags.StoresOnMarketplace, [FeatureFlagValues.Enable]],
+])
+
+export const getFlagsByParams = ({
+  url,
+}: {
+  url: URL
+}): Map<FeatureFlags, UndefinedOr<FeatureFlagValues>> => {
+  const _flags: [FeatureFlags, UndefinedOr<FeatureFlagValues>][] = Array.from(
+    flags.entries(),
+  ).map(([flag, values]) => {
+    return [
+      flag,
+      whenDefined(url.searchParams.get(`flag:${flag}`), (value) =>
+        values.includes(value as FeatureFlagValues)
+          ? (value as FeatureFlagValues)
+          : undefined,
+      ),
+    ]
+  })
+
+  return new Map(_flags)
+}

--- a/src/plugins/marketplace/admin.astro
+++ b/src/plugins/marketplace/admin.astro
@@ -13,14 +13,28 @@ import { allTags } from '@constants/plugins'
 import BannerPresetFeaturing from './components/BannerPresetFeaturing.astro'
 import ExternalToolWrapper from './components/ExternalToolWrapper.astro'
 
+import {
+  getFlagsByParams,
+  FeatureFlags,
+  FeatureFlagValues,
+} from '@fixtures/flags'
+import collections from '@plugins/collections'
+
 const { allInstallablePlugins, clubs } = Astro.props as ClubsPropsAdminPages & {
   allInstallablePlugins: InstallablePlugins[]
 }
 
+const flags = getFlagsByParams({ url: new URL(Astro.url) })
+
+const installablePlugins =
+  flags.get(FeatureFlags.StoresOnMarketplace) === FeatureFlagValues.Enable
+    ? allInstallablePlugins
+    : allInstallablePlugins.filter((plg) => plg.id !== collections.meta.id)
+
 const getPluginMeta = createGetPluginMeta(
   decode(clubs.encodedClubsConfiguration),
 )
-const allPlugins = await Promise.all(allInstallablePlugins.map(getPluginMeta))
+const allPlugins = await Promise.all(installablePlugins.map(getPluginMeta))
 
 const externalTools: ExternalTool[] = [
   {


### PR DESCRIPTION
- Add `@fixtures/flags` APIs
- Initially, the visibility of Stores plugin on the marketplace is controlled by the `flag:stores-on-marketplace` flag.