### PR TITLE
removes allowAccess check when publishing

### DIFF
--- a/src/components/PublishNetworkSelection/PublishNetworkSelection.vue
+++ b/src/components/PublishNetworkSelection/PublishNetworkSelection.vue
@@ -373,7 +373,6 @@ export default defineComponent({
       required: true,
     },
     showTestnets: Boolean,
-    allowAccess: Boolean,
     site: {
       type: String,
       required: true,
@@ -451,7 +450,6 @@ export default defineComponent({
       url.host = `${this.networkSelected.toLowerCase()}.${url.host}`
       const urlParams = new URLSearchParams(url.search)
       urlParams.set('popup', 'true')
-      this.allowAccess && urlParams.set('allowAccess', 'true')
       url.search = urlParams.toString()
       return url.toString()
     },

--- a/src/pages/[site]/setup/publish.astro
+++ b/src/pages/[site]/setup/publish.astro
@@ -16,7 +16,6 @@ import PageNotFound from '@pages/404.astro'
 const { site } = Astro.params
 
 const testnets = Astro.url.searchParams.get('testnets') === ''
-const allowAccess = Astro.url.searchParams.get('allowAccess') === 'true'
 
 const { getStaticPaths, getCurrentConfig } = adminFactory({
   config: async () => await _config(site),
@@ -67,7 +66,6 @@ const baseDomainUrl = ((url) => `${url.protocol}//${site}.${url.host}/`)(
           category={draftOptionsValue?.category}
           membershipsPluginOptions={membershipsPluginOptions}
           showTestnets={testnets}
-          allowAccess={allowAccess}
           config={config}
           site={site}
         />


### PR DESCRIPTION
#### Description of the change

Removes check for allowAccess when publishing. This was allowing selected users to publish in the Niwa popup. The check has been now removed from Niwa, and is no longer necessary in Clubs.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
