### PR TITLE
Fix issue on props passing

### DIFF
--- a/src/plugins/collections/checkout.astro
+++ b/src/plugins/collections/checkout.astro
@@ -16,7 +16,7 @@ const { membership, propertyAddress, rpcUrl, collection, ...other } =
 
 <Checkout_
   amount={membership.price}
-  destination={propertyAddress}
+  propertyAddress={propertyAddress}
   currency={membership.currency}
   rpcUrl={rpcUrl}
   payload={membership.payload}

--- a/src/plugins/collections/index.ts
+++ b/src/plugins/collections/index.ts
@@ -169,7 +169,7 @@ export const getPagePaths = (async (
       collection.memberships.map((membership) => ({
         paths: ['collections', 'checkout', bytes32Hex(membership.payload)],
         component: Checkout,
-        props: { collections, rpcUrl, collection, membership },
+        props: { collections, rpcUrl, propertyAddress, collection, membership },
       })),
     ) ?? []),
     {


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

As the title said.

Potential improvement candidates:
- Checkout.astro in clubs-core can use `Props` type declaration to provide better type to parent components.
- Checkout.astro in clubs-core basically uses the same named parameters as Checkout.vue, but replaces only `destination` with `propertyAddress`. This can be changed to use the same parameters as in Checkout.vue. 

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
