### PR TITLE
fix: remove prefetch from MembershipOption

### DIFF
--- a/src/components/AdminMembershipsForm/MembershipOption.svelte
+++ b/src/components/AdminMembershipsForm/MembershipOption.svelte
@@ -97,9 +97,9 @@
   })
 </script>
 
-<svelte:head>
+<!-- <svelte:head>
   <link rel="prefetch" href={imagePath} />
-</svelte:head>
+</svelte:head> -->
 
 <div
   class={`grid grid-rows-[auto_1fr] overflow-hidden rounded-xl shadow-2xl ${className}`}


### PR DESCRIPTION
#### Description of the change
Remove prefetch from svelte to load the newly uploaded image to IMGUR immediately.

