### PR TITLE
fix a bug that i18n parts on Domain page does not update even after mounted

### DIFF
--- a/src/components/Domain/Domain.vue
+++ b/src/components/Domain/Domain.vue
@@ -55,7 +55,7 @@ export default {
       this.daoName = this.namePreset
       this.verifySiteName()
     }
-    i18n = i18nBase(navigator.languages)
+    this.i18n = i18nBase(navigator.languages)
   },
   computed: {
     network() {


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

As the title says.

Maybe, we can write the same process in more natural way with composition API:
```js
const i18n = ref<ReturnType<typeof i18nBase>>()

onMounted(() => {
  i18n.value = i18nBase(navigator.languages)
})
```

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
