### PR TITLE
Enable regexp-paths-dependent route for pages/admins

### DIFF
--- a/src/pages/sites_/[site]/[...page].astro
+++ b/src/pages/sites_/[site]/[...page].astro
@@ -8,6 +8,7 @@ import {
   type ClubsFunctionFactoryOptions,
   type ClubsFunctionPageFactoryResult,
   type ClubsGetStaticPathsItem,
+  routerFactory,
 } from '@devprotocol/clubs-core'
 import { config as _config } from '@fixtures/config'
 import PageNotFound from '@pages/404.astro'
@@ -19,6 +20,7 @@ import Footer from '@components/Footer/Footer.astro'
 import { replaceWithFwdHost } from '@fixtures/url'
 import type { InferGetStaticPropsType } from 'astro'
 import Clarity from '@components/Clarity/Clarity.astro'
+import type { UndefinedOr } from '@devprotocol/util-ts'
 
 const { site, page } = Astro.params
 const config = await _config(site)
@@ -31,11 +33,10 @@ const options = {
 const { getStaticPaths } = pageFactory(
   options,
 ) as ClubsFunctionPageFactoryResult<typeof options>
-const path = (await getStaticPaths()).find(
-  ({ params }) => params.page === page,
-) as
-  | ClubsGetStaticPathsItem<InferGetStaticPropsType<typeof getStaticPaths>>
-  | undefined
+const router = routerFactory(await getStaticPaths(), (p) => p.params.page)
+const path = router(page) as UndefinedOr<
+  ClubsGetStaticPathsItem<InferGetStaticPropsType<typeof getStaticPaths>>
+>
 
 const Layout = path?.props.layout
 const Content = path?.props.component

--- a/src/pages/sites_/[site]/admin/[...page].astro
+++ b/src/pages/sites_/[site]/admin/[...page].astro
@@ -8,6 +8,7 @@ import {
   type ClubsFunctionFactoryOptions,
   type ClubsFunctionAdminFactoryResult,
   type ClubsGetStaticPathsItem,
+  routerFactory,
 } from '@devprotocol/clubs-core'
 import { config as _config } from '@fixtures/config'
 import PageNotFound from '@pages/404.astro'
@@ -34,9 +35,9 @@ const { getStaticPaths } = adminFactory(
   options,
 ) as ClubsFunctionAdminFactoryResult<typeof options>
 
-const _path = (await getStaticPaths()).find(
-  ({ params }) => params.page === page,
-)
+const router = routerFactory(await getStaticPaths(), (p) => p.params.page)
+const _path = router(page)
+
 const path = {
   ..._path,
   props: {


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

The regexp paths are already available in the API routes. But pages/admins ware not. This change allow pages/admins to enable regexp-paths-dependent routes.

With this change, some regexp-paths-dependent pages like https://github.com/dev-protocol/clubs-plugin-posts/pull/786 will be available on clubsx.

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
