### PR TITLE
`/api/profile/[id]` and `/api/hasCreationLimitReached/[id]` APIs are now returning cors header

### DIFF
--- a/src/pages/api/hasCreationLimitReached/[...identifier].ts
+++ b/src/pages/api/hasCreationLimitReached/[...identifier].ts
@@ -1,4 +1,5 @@
 import { hasCreationLimitReached } from './util'
+import { headers } from '@fixtures/api/headers'
 
 export const GET = async ({
   params: { identifier },
@@ -18,5 +19,6 @@ export const GET = async ({
     await hasCreationLimitReached(identifier)
   return new Response(JSON.stringify({ isCreationLimitReached }), {
     status: 200,
+    headers,
   })
 }

--- a/src/pages/api/profile/[id].ts
+++ b/src/pages/api/profile/[id].ts
@@ -1,4 +1,5 @@
 import { generateProfileId } from '@fixtures/api/keys'
+import { headers } from '@fixtures/api/headers'
 import { createClient } from 'redis'
 
 export const GET = async ({
@@ -30,5 +31,6 @@ export const GET = async ({
 
   return new Response(userProfile, {
     status: 200,
+    headers,
   })
 }


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

`/api/profile/[id]` and `/api/hasCreationLimitReached/[id]` returns cors headers now.

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
