### PR TITLE
Reorder display slots in default-theme index page

### DIFF
--- a/src/plugins/default-theme/pages/index.astro
+++ b/src/plugins/default-theme/pages/index.astro
@@ -29,6 +29,13 @@ const SlotsPageContentHomeAfterContent = clubs.slots.filter(({ slot }) => {
 
 <article class="grid gap-6">
   {
+    // Display slots of PageContentHomeBeforeContent
+    SlotsPageContentHomeBeforeContent.map((Slot) => (
+      <Slot.component {...Slot.props} />
+    ))
+  }
+
+  {
     sectionsOrderConfig && sectionsOrderConfig === 'about-first' ? (
       <>
         <h2 class="text-center text-xl font-bold lg:text-4xl">About {name}</h2>
@@ -58,13 +65,6 @@ const SlotsPageContentHomeAfterContent = clubs.slots.filter(({ slot }) => {
         )}
       </section>
     )
-  }
-
-  {
-    // Display slots of PageContentHomeBeforeContent
-    SlotsPageContentHomeBeforeContent.map((Slot) => (
-      <Slot.component {...Slot.props} />
-    ))
   }
 
   {


### PR DESCRIPTION
The display slots for PageContentHomeBeforeContent have been moved to the top of the 'grid gap-6' article within the default-theme index page. This change ensures the correct order of content rendering according to the sectionsOrderConfig setting.

#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [ ] Added description of the change
- [ ] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [ ] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
