### PR TITLE
feat: add logic to issue >=1 achievements in a single API call

### DIFF
--- a/src/plugins/achievements/handlers/addAchievement.ts
+++ b/src/plugins/achievements/handlers/addAchievement.ts
@@ -121,7 +121,7 @@ export const handler =
     )
 
     // 10. Return the id as response of the new data saved
-    return new Response(JSON.stringify({ id: achievementItemIds.join(', ') }), {
+    return new Response(JSON.stringify({ id: achievementItemIds }), {
       status: 200,
     })
   }

--- a/src/plugins/achievements/handlers/addAchievement.ts
+++ b/src/plugins/achievements/handlers/addAchievement.ts
@@ -121,7 +121,7 @@ export const handler =
     )
 
     // 10. Return the id as response of the new data saved
-    return new Response(JSON.stringify({ id: achievementItemIds }), {
+    return new Response(JSON.stringify({ ids: achievementItemIds }), {
       status: 200,
     })
   }

--- a/src/plugins/achievements/utils.ts
+++ b/src/plugins/achievements/utils.ts
@@ -37,13 +37,19 @@ export const getAchievementInfoDocument = (
 })
 
 /**
+ * Generate a new achievement item id
+ * @returns the generated new achievement item document's id for db.
+ */
+export const createAchievementItemId = () => nanoid(10)
+
+/**
  * Generate a new achievement info document
  * @param base - the achievement info item without ID
  * @returns the generated new achievement info document without ID duplication check
  */
 export const getAchievementItemDocument = (
   base: Omit<AchievementItem, 'id'>,
-): AchievementItem => ({ ...base, id: nanoid(10) }) // Here id will be unique as multiple users might have same achievement unlocked.
+): AchievementItem => ({ ...base, id: createAchievementItemId() }) // Here id will be unique as multiple users might have same achievement unlocked.
 
 /**
  * Returns string that available for searching as TAG


### PR DESCRIPTION
#### Description of the change
Modify the API to input a parameter `noOfCopies` which signifies the number of achievements to issue. Then create `noOfCopies` achievements (as apposed to creating 1 achievement only) and return the created achievements in the array format.

This change will allow us to assign multiple (>=1) achievements for a single record in airtable or api call.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: **The achievements created will all have the exactly same data.**
