### PR TITLE
feat: update staking ratio to 0% in memberships edit and create

### DIFF
--- a/src/components/AdminMembershipsForm/AdminMembershipsAdditionForm.svelte
+++ b/src/components/AdminMembershipsForm/AdminMembershipsAdditionForm.svelte
@@ -740,7 +740,7 @@
                     />
                   </svg>
                 </span>
-                Instant
+                {i18n('Instant')}
               </button>
               <button
                 on:click|preventDefault={() =>
@@ -769,7 +769,7 @@
                     />
                   </svg>
                 </span>
-                Stake
+                {i18n('Stake')}
               </button>
               <div class="max-w-[33%] grow">
                 {#if membershipPaymentType !== 'custom'}
@@ -779,7 +779,8 @@
                     class="hs-button is-large is-filled w-full max-w-full opacity-50"
                     id="membership-fee-custom"
                     name="membership-fee-custom"
-                    disabled={membership.currency === 'DEV'}>Custom</button
+                    disabled={membership.currency === 'DEV'}
+                    >{i18n('Custom')}</button
                   >
                 {/if}
                 {#if membershipPaymentType === 'custom'}

--- a/src/components/AdminMembershipsForm/i18n/index.ts
+++ b/src/components/AdminMembershipsForm/i18n/index.ts
@@ -74,6 +74,10 @@ export const Strings = {
     en: () => 'Minimum earning model fee allowed is',
     ja: () => '許容されている最小の収益モデルの手数料',
   },
+  PaidMinimumFee: {
+    en: () => 'Earning model fee is currently set to',
+    ja: () => 'モデル料金の獲得は現在次のように設定されています',
+  },
   PriceSetMin: {
     en: () => 'Price automatically set to minimum allowed value',
     ja: () => '価格は最小許容値に自動で設定されます',

--- a/src/components/AdminMembershipsForm/i18n/index.ts
+++ b/src/components/AdminMembershipsForm/i18n/index.ts
@@ -144,6 +144,18 @@ export const Strings = {
     en: () => `<u>the credit card plugin.</u>`,
     ja: () => 'USDCを選択してください',
   },
+  Instant: {
+    en: () => `Instant`,
+    ja: () => `インスタント`,
+  },
+  Stake: {
+    en: () => `Stake`,
+    ja: () => `ステーク`,
+  },
+  Custom: {
+    en: () => `Custom`,
+    ja: () => `カスタム`,
+  },
   EarningModel: {
     en: () => 'Earning Model',
     ja: () => '収益モデル',

--- a/src/constants/memberships.ts
+++ b/src/constants/memberships.ts
@@ -1,4 +1,9 @@
+export const MINIMUM_CUSTOM_FEE100 = 0
+export const MAXIMUM_CUSTOM_FEE100 = 95
+export const PAID_PLAN_STAKING_FEE = 1
 export const PAYMENT_TYPE_STAKE_FEE = 0.1
 export const PAYMENT_TYPE_INSTANT_FEE = 0.9
 export const DEV_TOKEN_PAYMENT_TYPE_FEE = 0
+export const PAID_PLAN_STAKING_FEE100 = 100
+export const DEV_TOKEN_PAYMENT_TYPE_FEE100 = 0
 export const ALL_CURRENCIES = ['USDC', 'DEV', 'ETH', 'MATIC']


### PR DESCRIPTION
The PR tries to add a 0% staking ratio (100% custom earning model) while updating and creating memberships.

Things to note:
- No changes from previous behaviour have been made when the currency is DEV.
- No changes from the previous behaviour have been made when the membership is unpriced.