### PR TITLE
feat: make default staking 0% and custom field max to 100

### DIFF
--- a/src/components/AdminMembershipsForm/AdminMembershipsAdditionForm.svelte
+++ b/src/components/AdminMembershipsForm/AdminMembershipsAdditionForm.svelte
@@ -12,6 +12,8 @@
   import { buildConfig } from '@devprotocol/clubs-core'
   import {
     DEV_TOKEN_PAYMENT_TYPE_FEE,
+    MAX_CUSTOM_FEE,
+    MIN_CUSTOM_FEE,
     PAYMENT_TYPE_INSTANT_FEE,
     PAYMENT_TYPE_STAKE_FEE,
   } from '@constants/memberships'
@@ -71,8 +73,8 @@
 
   const minPrice = 0.000001
   const maxPrice = 1e20
-  const minCustomFee100 = 0
-  const maxCustomFee100 = 95
+  const minCustomFee100 = MIN_CUSTOM_FEE
+  const maxCustomFee100 = MAX_CUSTOM_FEE
   const i18nBase = i18nFactory(Strings)
   let i18n = i18nBase(['en'])
 

--- a/src/components/AdminMembershipsForm/i18n/index.ts
+++ b/src/components/AdminMembershipsForm/i18n/index.ts
@@ -195,7 +195,7 @@ export const Strings = {
   },
   WillBeStaked: {
     // For example: "X USDC will will be staked to earn dev continuously."
-    en: () => 'will be staked to earn dev continuously.',
+    en: () => 'will be staked to earn DEV continuously.',
     ja: () => 'をステーキングして継続的にDEVを取得します',
   },
   ActionLabel: {

--- a/src/components/Collections/CreateCollections.svelte
+++ b/src/components/Collections/CreateCollections.svelte
@@ -1345,7 +1345,7 @@
               )
                 .dp(3)
                 .toString()}%)
-            </span> will be staked to earn dev continuously.
+            </span> will be staked to earn DEV continuously.
           </p>
           <p class="hs-form-field__helper mt-2">
             * <u>What is staking?</u>

--- a/src/constants/memberships.ts
+++ b/src/constants/memberships.ts
@@ -1,8 +1,8 @@
 export const NO_STAKE_FEE = 1
 export const MIN_CUSTOM_FEE = 0
-export const MAX_CUSTOM_FEE = 95
+export const MAX_CUSTOM_FEE = 100
 export const NO_STAKE_FEE100 = 100
 export const PAYMENT_TYPE_STAKE_FEE = 0.1
-export const PAYMENT_TYPE_INSTANT_FEE = 0.9
+export const PAYMENT_TYPE_INSTANT_FEE = 1
 export const DEV_TOKEN_PAYMENT_TYPE_FEE = 0
 export const ALL_CURRENCIES = ['USDC', 'DEV', 'ETH', 'MATIC']


### PR DESCRIPTION
#### Description of the change
- Modify the instant payment type to 1 (100%) and change limit of maxCustomFee100 to 100.

