### PR TITLE
feat: shops plugin payment plugin support.

### DIFF
--- a/src/plugins/clubs-payments/utils/compose-items.ts
+++ b/src/plugins/clubs-payments/utils/compose-items.ts
@@ -31,7 +31,8 @@ export const composeItems = (
         return 'memberships' in s ||
           'requiredMemberships' in s ||
           'endTime' in s
-          ? !!(s as Collection).memberships.find( // This is a collection, so find the membership and return boolean.
+          ? !!(s as Collection).memberships.find(
+              // This is a collection, so find the membership and return boolean.
               (m) => bytes32Hex(m.payload) === bytes32Hex(ov.payload),
             )
           : bytes32Hex(s.payload) === bytes32Hex(ov.payload) // This is a membership so directly compare payload.

--- a/src/plugins/clubs-payments/utils/compose-items.ts
+++ b/src/plugins/clubs-payments/utils/compose-items.ts
@@ -3,9 +3,11 @@ import {
   type ClubsFactoryUtils,
   type ClubsPluginOptions,
 } from '@devprotocol/clubs-core'
-import type { ComposedItem, Override } from '..'
 import { whenDefined, type UndefinedOr } from '@devprotocol/util-ts'
+
+import type { ComposedItem, Override } from '..'
 import type { Membership } from '@plugins/memberships'
+import type { Collection, CollectionMembership } from '@plugins/collections'
 
 export const composeItems = (
   options: ClubsPluginOptions,
@@ -23,7 +25,17 @@ export const composeItems = (
         sourceConfig?.options?.find((op) => op.key === ov.key)?.value as
           | undefined
           | Membership[]
-      )?.find((mem) => bytes32Hex(mem.payload) === bytes32Hex(ov.payload))
+          | Collection[]
+      )?.find((s) => {
+        // Check if the keys from collection object are present in s, if yes then it's a collection.
+        return 'memberships' in s ||
+          'requiredMemberships' in s ||
+          'endTime' in s
+          ? !!(s as Collection).memberships.find( // This is a collection, so find the membership and return boolean.
+              (m) => bytes32Hex(m.payload) === bytes32Hex(ov.payload),
+            )
+          : bytes32Hex(s.payload) === bytes32Hex(ov.payload) // This is a membership so directly compare payload.
+      })
       const composed = whenDefined(source, (so) => ({ ...ov, source: so }))
       return composed
     })

--- a/src/plugins/collections/index.ts
+++ b/src/plugins/collections/index.ts
@@ -47,6 +47,7 @@ export type Collection = {
   memberships: CollectionMembership[]
   requiredMemberships?: string[]
 }
+
 export const getApiPaths = (async (
   options,
   config,

--- a/src/plugins/memberships/index.ts
+++ b/src/plugins/memberships/index.ts
@@ -43,6 +43,7 @@ export type Membership = {
     description: string
   }
 }
+
 export type UnpricedMembership = Omit<Membership, 'price' | 'currency'>
 export type PricedMembership = UnpricedMembership & {
   price: NonNullable<Membership['price']>


### PR DESCRIPTION
#### Description of the change
- In compose items add support for shops plugin elements. The compose items function find the membership with the matching payload in shops plugin and returns the entire collection even if one membership of that collection matches the payload.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.
