### PR TITLE
Any changes in main always triggers prerelease deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on: [push, pull_request]
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,36 @@
+name: Deploy - Preview
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  workflow_run:
+    workflows: ['Build']
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy
+        id: deploy
+        run: |
+          output=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "::set-output name=url::$output"
+        shell: bash
+
+      - name: Alias Prerelease
+        run: vercel alias ${{ steps.deploy.outputs.url }} prerelease.clubs.place --token=${{ secrets.VERCEL_TOKEN }} --scope devprtcl
+
+      - name: Alias Wildcare Prerelease
+        run: vercel alias ${{ steps.deploy.outputs.url }} *.prerelease.clubs.place --token=${{ secrets.VERCEL_TOKEN }} --scope devprtcl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,18 @@
-name: Production Tag Deployment
+name: Deploy - Live
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 on:
   release:
     types: [published]
 
 jobs:
-  Deploy:
+  Check:
     runs-on: ubuntu-latest
+    outputs:
+      isPrerelease: ${{ steps.check.outputs.isPrerelease }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Vercel CLI
@@ -21,21 +25,18 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" \
             | jq '.prerelease')
           echo "::set-output name=isPrerelease::$IS_PRERELEASE"
+
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: Check
+    if: needs.Check.outputs.isPrerelease != 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=${{ steps.check.outputs.isPrerelease == 'true' && 'preview' || 'production' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts
-        run: vercel build ${{ steps.check.outputs.isPrerelease == 'true' && ' ' || '--prod' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy
-        id: deploy
-        run: |
-          output=$(vercel deploy --prebuilt ${{ steps.check.outputs.isPrerelease == 'true' && ' ' || '--prod' }} --token=${{ secrets.VERCEL_TOKEN }})
-          echo "::set-output name=url::$output"
-        shell: bash
-
-      - name: Alias Prerelease
-        if: steps.check.outputs.isPrerelease == 'true'
-        run: vercel alias ${{ steps.deploy.outputs.url }} prerelease.clubs.place --token=${{ secrets.VERCEL_TOKEN }} --scope devprtcl
-
-      - name: Alias Wildcare Prerelease
-        if: steps.check.outputs.isPrerelease == 'true'
-        run: vercel alias ${{ steps.deploy.outputs.url }} *.prerelease.clubs.place --token=${{ secrets.VERCEL_TOKEN }} --scope devprtcl
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,44 +16,22 @@ yarn dev
 
 Use `npm version` to manage git tags and update hosted Clubs by publishing them as GitHub Releases.
 
-### pre-release
-
-If you are incrementing a pre-release version that already exists:
-
-```bash
-npm version prerelease
-git push && git push --tags
-```
-
-To create a new pre-release version from an existing stable release version:
-
-```bash
-npm version preminor --preid beta
-# Depending on the changes, [prepatch|premajor] can also be used
-git push && git push --tags
-```
-
-### stable release
-
-When turning a pre-release into a stable release or updating a stable release, do the following:
-
 ```bash
 npm version [patch|minor|major]
 git push && git push --tags
 ```
 
-### hotfix
+Semantic versioning can basically be determined by the following rules:
 
-If a bug in the stable release version is fixed in the pre-release version, you may want to apply it to the stable release version immediately.
+| command               | when                                               |
+| --------------------- | -------------------------------------------------- |
+| npm version **patch** | Bug fixes, Updates without changing functionality. |
+| npm version **minor** | Updates without breaking changes.                  |
+| npm version **major** | Major updates with breaking changes.               |
 
-In such cases, you can `checkout` the stable release version of the git tag, `cherry-pick` specific fix commit(s), and publish the new tag as the new stable release version. This is called a hotfix.
+### pre-release
 
-```bash
-git checkout refs/tags/<LATEST_PRODUCTION_TAG_NAME> # ig, refs/tags/0.1.0
-git cherry-pick <COMMIT_SHA1> # ig, 721f2af8ffae1a012317f25521cdaa934a023f4b
-git tag <NEW_TAG_NAME> # ig, 0.1.0-hotfix.1
-git push --tags # Push only the tag
-```
+Changes to the `main` branch are always automatically deployed as prereleases.
 
 ## setup env file
 


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

Updated the deployment pipeline conditions to ensure that any changes to the `main` branch are automatically deployed as a prerelease.

Meanwhile, deployments to the live environment will still require the creation of a release.

This adjustment simplifies the management of semantic versioning by removing the necessity for npm version updates for prereleases.

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
