### PR TITLE
feat: filter all sTokens into 'nft' (membership) and 'passport-item'

### DIFF
--- a/src/fixtures/api/assets/schema.ts
+++ b/src/fixtures/api/assets/schema.ts
@@ -75,8 +75,10 @@ export const nBalance = {
   },
 } satisfies RediSearchSchema
 
+export type AssetContractType = 'sTokens' | 'sbt' | 'property'
+
 export type AssetDocument = {
-  type: 'nft' | 'sbt' | 'property'
+  type: 'nft' | 'sbt' | 'property' | 'passport-item'
   id?: string
   nId?: number
   contract: string

--- a/src/fixtures/api/assets/schema.ts
+++ b/src/fixtures/api/assets/schema.ts
@@ -95,7 +95,7 @@ export type AssetDocument = {
   nBlock: number
   balance: string
   nBalance: number
-  payload: string | undefined
+  payload?: string
 }
 
 export const assetDocument = (doc: {
@@ -106,7 +106,7 @@ export const assetDocument = (doc: {
   owner: string
   block: string | bigint | number
   balance: string | bigint | number
-  payload: string | undefined
+  payload?: string
 }): AssetDocument => ({
   type: doc.type,
   id: doc.id ? doc.id.toString() : undefined,

--- a/src/fixtures/api/assets/schema.ts
+++ b/src/fixtures/api/assets/schema.ts
@@ -115,6 +115,13 @@ export const assetDocumentTypes: ReadonlyArray<AssetDocument['type']> = [
   'nft',
   'property',
   'sbt',
+  'passport-item',
+]
+
+export const assetContractTypes: ReadonlyArray<AssetContractType> = [
+  'sTokens',
+  'property',
+  'sbt',
 ]
 
 export type LogDocument = {

--- a/src/fixtures/api/assets/schema.ts
+++ b/src/fixtures/api/assets/schema.ts
@@ -75,6 +75,13 @@ export const nBalance = {
   },
 } satisfies RediSearchSchema
 
+export const payload = {
+  '$.payload': {
+    type: SchemaFieldTypes.TEXT,
+    AS: 'payload',
+  },
+} satisfies RediSearchSchema
+
 export type AssetContractType = 'sTokens' | 'sbt' | 'property'
 
 export type AssetDocument = {
@@ -88,6 +95,7 @@ export type AssetDocument = {
   nBlock: number
   balance: string
   nBalance: number
+  payload: string | undefined
 }
 
 export const assetDocument = (doc: {
@@ -98,6 +106,7 @@ export const assetDocument = (doc: {
   owner: string
   block: string | bigint | number
   balance: string | bigint | number
+  payload: string | undefined
 }): AssetDocument => ({
   type: doc.type,
   id: doc.id ? doc.id.toString() : undefined,
@@ -109,6 +118,7 @@ export const assetDocument = (doc: {
   nId: doc.id ? Number(doc.id) : undefined,
   nBlock: Number(doc.block),
   nBalance: Number(doc.balance),
+  payload: doc.payload ?? undefined,
 })
 
 export const assetDocumentTypes: ReadonlyArray<AssetDocument['type']> = [
@@ -141,6 +151,7 @@ export const ASSET_SCHEMA = {
   ...nId,
   ...nBlock,
   ...nBalance,
+  ...payload,
 }
 
 export const LOG_SCHEMA = {

--- a/src/fixtures/api/assets/utils.ts
+++ b/src/fixtures/api/assets/utils.ts
@@ -6,12 +6,7 @@ import {
   type UndefinedOr,
   whenDefinedAll,
 } from '@devprotocol/util-ts'
-import {
-  Contract,
-  type ContractRunner,
-  type InterfaceAbi,
-  type Provider,
-} from 'ethers'
+import { Contract, type InterfaceAbi, type Provider } from 'ethers'
 import {
   getDefaultClient,
   Index,
@@ -22,6 +17,7 @@ import type { AsyncReturnType } from 'type-fest'
 import {
   assetDocument,
   contract,
+  type AssetContractType,
   type AssetDocument,
   type LogDocument,
 } from '@fixtures/api/assets/schema'
@@ -61,14 +57,20 @@ export const fetchAssets = async ({
   redis,
   contractAddress,
   abi,
-  type,
+  contractType,
+  assetTypeFetcher,
   propertyAddressFetcher,
 }: {
   provider: Provider
   redis: AsyncReturnType<typeof getDefaultClient>
   contractAddress: string
   abi: InterfaceAbi
-  type: AssetDocument['type']
+  contractType: AssetContractType
+  assetTypeFetcher: (
+    type: AssetContractType,
+    id?: string,
+    contract?: Contract,
+  ) => Promise<AssetDocument['type']>
   propertyAddressFetcher?: (
     contract: Contract,
     id: string,
@@ -155,21 +157,25 @@ export const fetchAssets = async ({
       ) ?? evs,
   )
 
-  const assetDocs = whenNotError(withProperties, (events) =>
-    events
-      .filter(isNotError)
-      .map(({ id, to: owner, block, propertyAddress }) => {
-        const doc = assetDocument({
-          type,
-          contract: contractAddress,
-          id,
-          owner,
-          block,
-          balance: '1',
-          propertyAddress,
-        })
-        return doc
-      }),
+  const assetDocs = await whenNotErrorAll(
+    [nft, withProperties],
+    ([_nft, events]) =>
+      Promise.all(
+        events
+          .filter(isNotError)
+          .map(async ({ id, to: owner, block, propertyAddress }) => {
+            const doc = assetDocument({
+              type: await assetTypeFetcher(contractType, id, _nft),
+              contract: contractAddress,
+              id,
+              owner,
+              block,
+              balance: '1',
+              propertyAddress,
+            })
+            return doc
+          }),
+      ),
   )
 
   console.log({ contractAddress, assetDocs })

--- a/src/fixtures/api/assets/utils.ts
+++ b/src/fixtures/api/assets/utils.ts
@@ -70,6 +70,7 @@ export const fetchAssets = async ({
     type: AssetContractType,
     id?: string,
     contract?: Contract,
+    client?: AsyncReturnType<typeof getDefaultClient>,
   ) => Promise<AssetDocument['type']>
   propertyAddressFetcher?: (
     contract: Contract,
@@ -165,7 +166,7 @@ export const fetchAssets = async ({
           .filter(isNotError)
           .map(async ({ id, to: owner, block, propertyAddress }) => {
             const doc = assetDocument({
-              type: await assetTypeFetcher(contractType, id, _nft),
+              type: await assetTypeFetcher(contractType, id, _nft, redis),
               contract: contractAddress,
               id,
               owner,

--- a/src/fixtures/api/assets/utils.ts
+++ b/src/fixtures/api/assets/utils.ts
@@ -71,7 +71,10 @@ export const fetchAssets = async ({
     id?: string,
     contract?: Contract,
     client?: AsyncReturnType<typeof getDefaultClient>,
-  ) => Promise<AssetDocument['type']>
+  ) => Promise<{
+    assetType: AssetDocument['type']
+    assetPayload: string | undefined
+  }>
   propertyAddressFetcher?: (
     contract: Contract,
     id: string,
@@ -165,14 +168,21 @@ export const fetchAssets = async ({
         events
           .filter(isNotError)
           .map(async ({ id, to: owner, block, propertyAddress }) => {
+            const assetTypeAndPayload = await assetTypeFetcher(
+              contractType,
+              id,
+              _nft,
+              redis,
+            )
             const doc = assetDocument({
-              type: await assetTypeFetcher(contractType, id, _nft, redis),
+              type: assetTypeAndPayload.assetType,
               contract: contractAddress,
               id,
               owner,
               block,
               balance: '1',
               propertyAddress,
+              payload: assetTypeAndPayload.assetPayload,
             })
             return doc
           }),


### PR DESCRIPTION
#### Description of the change
Add an assetFetcherType which fetches and confirms the type of smart-contract used. If it's a sToken we then fetch payload in the passport-item redis schemas. If the payload is found there we conclude it's a passport-item.
