### PR TITLE
feat: update passport feature for name, and id and add nanoid routing

### DIFF
--- a/src/pages/api/profile/index.ts
+++ b/src/pages/api/profile/index.ts
@@ -11,6 +11,8 @@ export type Clip = {
 }
 
 export type Skin = {
+  id: string // Nano id
+  name: string // identifier for passport config
   theme: Payload // Pointing to PassportItem.sTokenPayload
   clips?: Clip[] // Token payloads of pinned clips
   videos?: Payload[] // for the future use cases

--- a/src/pages/api/profile/updateLike.ts
+++ b/src/pages/api/profile/updateLike.ts
@@ -8,11 +8,7 @@ export const POST = async ({ request }: { request: Request }) => {
     profileId: string
     skinIndex: number
   }
-  console.log('ProfileId', profileId)
-  console.log('SkinIndex', skinIndex)
   const profile: Profile = await getProfile({ id: profileId })
-
-  console.log('Old profile skins', profile.skins)
 
   if (!profile) {
     return new Response(JSON.stringify({ error: 'No profile found' }), {
@@ -31,7 +27,7 @@ export const POST = async ({ request }: { request: Request }) => {
       return skin
     }),
   }
-  console.log('Skins', newProfile.skins)
+
   const client = createClient({
     url: process.env.REDIS_URL,
     username: process.env.REDIS_USERNAME ?? '',

--- a/src/pages/passport/[eoa]/[...ids]/index.astro
+++ b/src/pages/passport/[eoa]/[...ids]/index.astro
@@ -1,0 +1,279 @@
+---
+import { isAddress } from 'ethers'
+import type { Profile } from '@pages/api/profile'
+import { getProfile } from '@fixtures/api/profile'
+import { whenDefined } from '@devprotocol/util-ts'
+import { passportClass } from '@fixtures/ui/passport'
+import { getPassportItemForPayload } from '@fixtures/api/passportItem'
+import { markdownToHtml, ProseTextInherit } from '@devprotocol/clubs-core'
+
+import Layout from '../../Layout.astro'
+import dummyData from '../../dummyData.json'
+import Icon from '../../components/Icons.vue'
+import type { PassportClip } from '../../types'
+import Like from '../../components/Like.svelte'
+import UserAssets from '../../components/UserAssets.vue'
+import PassportClips from '../../components/PassportClips.vue'
+import UserProfileEditButton from '../../components/UserProfileEditButton.svelte'
+
+const { eoa, ids } = Astro.params
+const isEOA = isAddress(eoa)
+
+const id = ids?.split('/')?.at(0) ?? '' // Get the skin id from the URL.
+const profile: Profile = await getProfile({ id: eoa ?? '' })
+
+const isLocal =
+  Astro.url.hostname.includes('localhost') ||
+  /^[\d\.]+$/.test(Astro.url.hostname)
+
+const htmlDescription = markdownToHtml(profile.description)
+
+const skin = profile?.skins?.find((skin) => skin.id === id)
+const _passportSkinBGMs = skin?.bgm
+const _passportSkinClips = skin?.clips
+const _passportSkinVideos = skin?.videos
+const _currentLikes = skin?.likes
+
+const passportSkinBGMs = await whenDefined(_passportSkinBGMs, () =>
+  getPassportItemForPayload({
+    sTokenPayload: _passportSkinBGMs ?? '',
+  })
+    .then((item) => (item instanceof Error ? undefined : item))
+    .catch(() => undefined),
+)
+
+const passportSkinVideos = await whenDefined(
+  _passportSkinVideos,
+  async (videos) => {
+    if (!videos.length) {
+      return undefined
+    }
+
+    return Promise.all(
+      videos.map((item) =>
+        getPassportItemForPayload({ sTokenPayload: item ?? '' })
+          .then((item) => (item instanceof Error ? undefined : item))
+          .catch(() => undefined),
+      ) ?? [],
+    )
+      .then((items) => items.filter((items) => !!items))
+      .then((items) => (items.length ? items : undefined))
+      .catch(() => undefined)
+  },
+)
+
+const passportSkinClips = await whenDefined(
+  _passportSkinClips,
+  async (clips) => {
+    if (!clips.length) {
+      return undefined
+    }
+
+    return Promise.all(
+      clips.map((item) =>
+        getPassportItemForPayload({ sTokenPayload: item.payload ?? '' })
+          .then(
+            (clip) =>
+              (clip instanceof Error
+                ? undefined
+                : {
+                    ...clip,
+                    description: item.description,
+                    frameColorHex: item.frameColorHex,
+                  }) as PassportClip,
+          )
+          .catch(() => undefined),
+      ) ?? [],
+    )
+      .then((items) => items.filter((items) => !!items))
+      .then((items) => (items.length ? items : undefined))
+      .catch(() => undefined)
+  },
+)
+---
+
+<Layout theme="auto" sTokenPayload={profile?.skins?.at(0)?.theme}>
+  <div class="grid gap-24 clear-right">
+    <section class:list={passportClass('account-container')}>
+      <span
+        class="grid grid-cols-[6rem_1fr] lg:grid-cols-[10rem_1fr_auto] justify-items-start max-w-screen-lg mx-auto px-4 gap-6 lg:gap-y-8"
+        class:list={passportClass('account-content')}
+      >
+        <span
+          class="col-start-1 col-span-1"
+          class:list={passportClass('avatar-container')}
+        >
+          <span
+            class="flex flex-col items-center p-1.5 lg:p-2 rounded-full bg-surface-300"
+            class:list={passportClass('avatar-content')}
+          >
+            <img
+              src={profile.avatar}
+              class="rounded-full object-cover w-full aspect-square bg-lightgray bg-cover bg-center bg-no-repeat"
+              class:list={passportClass('avatar')}
+              alt="Profile"
+            />
+          </span>
+        </span>
+        <span
+          class="col-start-2 col-span-1 content-center"
+          class:list={passportClass('username-container')}
+        >
+          <span
+            class="flex justify-center items-center gap-6 px-3 py-1.5 lg:px-6 lg:py-3 rounded-xl bg-surface-200"
+            class:list={passportClass('username-content')}
+          >
+            <span
+              class="text-2xl lg:text-4xl font-bold"
+              class:list={passportClass('username')}
+            >
+              {profile.username}
+            </span>
+
+            <UserProfileEditButton
+              client:only="svelte"
+              id={eoa}
+              additionalClasses={passportClass('edit-button')}
+            />
+          </span>
+        </span>
+
+        {
+          passportSkinBGMs && (
+            <span
+              class="col-start-1 row-start-2 lg:col-start-3 lg:row-start-1 col-span-1 row-span-1 content-center"
+              class:list={passportClass('music-container')}
+            >
+              <span
+                class="flex items-center gap-[15px] px-[16px] py-[8px] rounded-lg bg-surface-200"
+                class:list={passportClass('music-content')}
+              >
+                <span class="opacity-50">
+                  <Icon icon="muted" />
+                </span>
+
+                <span>
+                  <Icon icon="music_waves" />
+                </span>
+
+                <span class="truncate font-bold">{dummyData.musicName}</span>
+              </span>
+            </span>
+          )
+        }
+
+        {
+          profile?.sns && (
+            <span
+              class="col-start-1 col-span-2 lg:col-span-3 row-start-3 row-span-1 lg:row-start-2"
+              class:list={passportClass('links-container')}
+            >
+              <span
+                class="grid grid-cols-5 items-start gap-6 p-3 rounded-lg bg-white"
+                class:list={passportClass('links-content')}
+              >
+                <a
+                  href={`https://x.com/${profile?.sns?.x}`}
+                  target="_blank"
+                  class={`${profile?.sns?.x ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                >
+                  <Icon icon="x" />
+                </a>
+                <a
+                  href={`https://twitch.tv/${profile?.sns?.twitch}`}
+                  target="_blank"
+                  class={`${profile?.sns?.twitch ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                >
+                  <Icon icon="twitch" />
+                </a>
+                <a
+                  href={`https://instagram.com/${profile?.sns?.instagram}`}
+                  target="_blank"
+                  class={`${profile?.sns?.instagram ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                >
+                  <Icon icon="instagram" />
+                </a>
+                <a
+                  href={`https://tiktok.com/${profile?.sns?.tiktok}`}
+                  target="_blank"
+                  class={`${profile?.sns?.tiktok ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                >
+                  <Icon icon="tiktok" />
+                </a>
+                <a
+                  href={`https://youtube.com/${profile?.sns?.youtube}`}
+                  target="_blank"
+                  class={`${profile?.sns?.youtube ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                >
+                  <Icon icon="youtube" />
+                </a>
+              </span>
+            </span>
+          )
+        }
+
+        <span
+          class="col-start-1 col-span-2 lg:col-span-3 row-start-4 lg:row-start-3 row-span-1 w-full"
+          class:list={[passportClass('description-container')]}
+        >
+          <span
+            class="flex w-full justify-center items-center gap-2.5 p-4 self-stretch block rounded-xl"
+            class:list={[passportClass('description-content')]}
+          >
+            <div
+              class:list={[ProseTextInherit, passportClass('description')]}
+              set:html={htmlDescription}
+            />
+          </span>
+        </span>
+      </span>
+    </section>
+
+    {
+      passportSkinVideos && (
+        <section class="grid justify-items-start max-w-screen-lg mx-auto px-4 gap-24 mb-10">
+          <span class:list={passportClass('video-container')}>
+            <span class:list={passportClass('video-content')}>
+              <img
+                src={dummyData.videoThumbnail}
+                class="w-full h-auto aspect-video rounded-sm"
+                class:list={passportClass('video')}
+                alt="Video"
+              />
+            </span>
+          </span>
+        </section>
+      )
+    }
+
+    <section
+      class="grid justify-items-start max-w-screen-lg mx-auto px-4 gap-24 mb-10"
+    >
+      {
+        passportSkinClips?.length && (
+          <div class:list={passportClass('clips-container')}>
+            <div class:list={passportClass('clips-content')}>
+              <PassportClips client:only="vue" clips={passportSkinClips} />
+            </div>
+          </div>
+        )
+      }
+
+      {isEOA && <UserAssets client:load account={eoa ?? ''} local={isLocal} />}
+
+      <a href={`/passport/${eoa}/clubs`} class="hs-link place-self-start"
+        >Clubs</a
+      >
+    </section>
+  </div>
+  <div class="sticky float-right bottom-0 p-2 lg:p-6">
+    <Like
+      client:load
+      props={{
+        profileId: eoa ? eoa : '',
+        currentLikes: _currentLikes ? _currentLikes : 0,
+        skinIndex: 0,
+      }}
+    />
+  </div>
+</Layout>

--- a/src/pages/passport/components/UserProfileEdit.svelte
+++ b/src/pages/passport/components/UserProfileEdit.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { nanoid } from 'nanoid'
   import { onMount } from 'svelte'
   import { JsonRpcProvider } from 'ethers'
   import { fade } from 'svelte/transition'
@@ -277,6 +278,24 @@
 
   const addProfile = async () => {}
 
+  const onChangePassportSkinName = (ev: Event) => {
+    const newName =
+      (event?.target as HTMLInputElement)?.value ??
+      profile?.skins?.at(0)?.name ??
+      profileFromAPI?.skins?.at(0)?.name ??
+      ''
+
+    profile = {
+      ...profile,
+      skins: [
+        {
+          ...(profile?.skins?.at(0) ?? ({} as Skin)), // Retain other skin properties irrespective of whether the skin is modified or not.
+          name: newName,
+        },
+      ],
+    }
+  }
+
   const selectPassportSkinItem = (item: PassportItem) => {
     if (!item.payload) {
       console.log(
@@ -473,6 +492,21 @@
     }
 
     closeAllModals()
+  }
+
+  $: {
+    // generate id only once (i.e when profile or skins or skins(0) or skins(0).id is not present)
+    if (!profileFromAPI?.skins?.at(0)?.id) {
+      profile = {
+        ...profile,
+        skins: [
+          {
+            ...(profile?.skins?.at(0) ?? ({} as Skin)), // Retain other skin properties irrespective of whether the skin is modified or not.
+            id: nanoid(),
+          },
+        ],
+      }
+    }
   }
 </script>
 
@@ -787,6 +821,17 @@
         />
       </div>
     </div>
+  </label>
+
+  <label class="hs-form-field is-filled mt-[76px]">
+    <span class="hs-form-field__label"> {i18n('PassportSkinName')} </span>
+    <input
+      class="hs-form-field__input"
+      disabled={profileUpdating || !eoa}
+      value={profile?.skins?.at(0)?.name ?? ''}
+      on:change|preventDefault={onChangePassportSkinName}
+      placeholder={i18n('PassportSkinNamePlaceholder')}
+    />
   </label>
 
   <label class="hs-form-field is-filled mt-[76px]">

--- a/src/pages/passport/i18n/index.ts
+++ b/src/pages/passport/i18n/index.ts
@@ -1,6 +1,10 @@
 import type { ClubsI18nParts } from '@devprotocol/clubs-core'
 
 export const Strings = {
+  PassportSkinName: {
+    en: 'Passport name',
+    ja: `パスポート名`,
+  },
   FrameColor: {
     en: `Frame color`,
     ja: `フレームカラー`,
@@ -16,6 +20,10 @@ export const Strings = {
   DescriptionPlaceholder: {
     en: `Describe yourself here.`,
     ja: `ここに自分自身について説明してください。`,
+  },
+  PassportSkinNamePlaceholder: {
+    en: `Enter a name that you would like to give to this passport`,
+    ja: `このパスポートに付けたい名前を入力してください`,
   },
   UsernamePlaceholder: {
     en: `Enter your username.`,


### PR DESCRIPTION
@aggre  This PR:

- Adds id and name to profile.skins[0].
- The passport skin name is an input field.
- The passport skin id is nanoid generated only when it is not present (meaning it's generated only once).

- Adds routing based on skin.id.
- if id is not present will return basic user page (with name, description, sns, clubs and achievements). will not show passport items.