### PR TITLE
perf: add optional caching in getProfile to help edit page get updated results

### DIFF
--- a/src/pages/api/profile/[id]/index.ts
+++ b/src/pages/api/profile/[id]/index.ts
@@ -1,22 +1,26 @@
-import { headers, cache } from '@fixtures/api/headers'
-import { getProfile } from '@fixtures/api/profile'
+import type { APIContext } from 'astro'
 import { json } from '@fixtures/api/json'
+import { getProfile } from '@fixtures/api/profile'
+import { headers, cache } from '@fixtures/api/headers'
 
 export const GET = async ({
   params: { id },
+  url,
 }: {
   params: { id: string | undefined }
+  url: APIContext['url']
 }) => {
   if (!id) {
     return new Response(JSON.stringify({ error: 'No profile ID passed' }), {
       status: 401,
     })
   }
+  const noCache = url.searchParams.get('nocache') === 'true' ? true : false
 
   const profile = await getProfile({ id })
 
   return new Response(json(profile), {
     status: 200,
-    headers: { ...headers, ...cache({ maxAge: 30 }) },
+    headers: { ...headers, ...cache({ maxAge: noCache ? 0 : 30 }) },
   })
 }

--- a/src/pages/passport/components/UserProfileEdit.svelte
+++ b/src/pages/passport/components/UserProfileEdit.svelte
@@ -68,8 +68,6 @@
     connection().account.subscribe((acc: UndefinedOr<string>) => {
       const oldEOA = eoa
       eoa = acc
-      // :TODO: DELETE THE LINE
-      // eoa = '0xfc4a9e2B406C515415BBcF502A632aefB185A875'
       if (eoa !== oldEOA) {
         // Wallet is connected or addrress has changed so update the data again.
         _fetchProfile()
@@ -238,7 +236,6 @@
       updatingStatus = undefined
       if (isReqSuccessful) {
         _fetchProfile()
-        // location.reload()
       }
     }, 3000)
   }
@@ -263,7 +260,6 @@
       const isReqSuccessful = createNewSkinStatus === 'success'
       createNewSkinStatus = undefined
       if (isReqSuccessful) {
-        await _fetchProfile()
         window.location.href = `/passport/${eoa}/edit?skinId=${newSkin.id}`
       }
     }, 3000)
@@ -296,7 +292,6 @@
       selectAsDefaultSkinStatus = undefined
       if (isReqSuccessful) {
         _fetchProfile()
-        // window.location.reload()
       }
     }, 3000)
   }
@@ -340,7 +335,6 @@
       toggleSkinVisibilityStatus = undefined
       if (isReqSuccessful) {
         _fetchProfile()
-        // window.location.reload()
       }
     }, 3000)
   }

--- a/src/pages/passport/components/UserProfileEdit.svelte
+++ b/src/pages/passport/components/UserProfileEdit.svelte
@@ -237,7 +237,8 @@
       const isReqSuccessful = updatingStatus === 'success'
       updatingStatus = undefined
       if (isReqSuccessful) {
-        location.reload()
+        _fetchProfile()
+        // location.reload()
       }
     }, 3000)
   }
@@ -258,10 +259,11 @@
     createNewSkinStatus = await submit()
     isCreatingNewSkin = false
 
-    setTimeout(() => {
+    setTimeout(async () => {
       const isReqSuccessful = createNewSkinStatus === 'success'
       createNewSkinStatus = undefined
       if (isReqSuccessful) {
+        await _fetchProfile()
         window.location.href = `/passport/${eoa}/edit?skinId=${newSkin.id}`
       }
     }, 3000)
@@ -293,7 +295,8 @@
       const isReqSuccessful = selectAsDefaultSkinStatus === 'success'
       selectAsDefaultSkinStatus = undefined
       if (isReqSuccessful) {
-        window.location.reload()
+        _fetchProfile()
+        // window.location.reload()
       }
     }, 3000)
   }
@@ -336,7 +339,8 @@
       const isReqSuccessful = toggleSkinVisibilityStatus === 'success'
       toggleSkinVisibilityStatus = undefined
       if (isReqSuccessful) {
-        window.location.reload()
+        _fetchProfile()
+        // window.location.reload()
       }
     }, 3000)
   }

--- a/src/pages/passport/components/UserProfileEdit.svelte
+++ b/src/pages/passport/components/UserProfileEdit.svelte
@@ -79,7 +79,8 @@
   const _fetchProfile = async () => {
     profileFetching = true
 
-    const fetchedProfile = await fetch(`/api/profile/${id}`)
+    // Avoid caching to get results of state update in all calls.
+    const fetchedProfile = await fetch(`/api/profile/${id}?nocache=true`)
       .then(
         (res) => {
           if (res.ok) {


### PR DESCRIPTION
#### Description of the change
Add optional caching in the getProfile API. This is to help the passport edit page get the updated profile in all the API calls.

#### Checklist

**I agree to the following :-**

- [x] Added description of the change
- [x] I've read the [contributing guidelines](https://github.com/WebXDAO/devprotocol.xyz/blob/main/CONTRIBUTING.md)
- [x] Search previous suggestions before making a new PR, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.