### PR TITLE
fix: clip ids when combined with other doc should always be id of res…

### DIFF
--- a/src/pages/passport/components/EditPassportSkinShowcase.svelte
+++ b/src/pages/passport/components/EditPassportSkinShowcase.svelte
@@ -163,9 +163,15 @@
   }
 
   const clips = (prof: Profile) => prof.skins?.at(skinIndex)?.clips
-  const purchasedClipsBySkinClip = (clip: Clip, items: PassportItem[]) =>
-    (clip.link ? clip : undefined) ??
-    items.find((x) => x.assetId === clip.sTokenId)
+  const purchasedClipsBySkinClip = (clip: Clip, items: PassportItem[]) => {
+    const data =
+      (clip.link ? clip : undefined) ??
+      items.find((x) => x.assetId === clip.sTokenId)
+    return {
+      ...data,
+      id: clip?.id, // the id should always point to clip id and not assetDocId or passportDocId or anyother id.
+    }
+  }
 </script>
 
 <!-- Edit passport skin showcase clips -->

--- a/src/pages/passport/components/EditPassportSkinShowcase.svelte
+++ b/src/pages/passport/components/EditPassportSkinShowcase.svelte
@@ -130,7 +130,7 @@
                         method === 'patch'
                           ? [
                               ...(skin.clips?.map((clip) =>
-                                clip.sTokenId === item.assetId
+                                clip.id === item.id
                                   ? {
                                       ...clip,
                                       id: clip.id ?? nanoid(),

--- a/src/pages/passport/components/EditPassportSkinSpotlight.svelte
+++ b/src/pages/passport/components/EditPassportSkinSpotlight.svelte
@@ -122,7 +122,7 @@
                         method === 'patch'
                           ? [
                               ...(skin.spotlight?.map((clip) =>
-                                clip.sTokenId === item.assetId
+                                clip.id === item.id
                                   ? {
                                       ...clip,
                                       id: clip.id ?? nanoid(),

--- a/src/pages/passport/components/EditPassportSkinSpotlight.svelte
+++ b/src/pages/passport/components/EditPassportSkinSpotlight.svelte
@@ -154,9 +154,15 @@
   }
 
   const spotlight = (prof: Profile) => prof.skins?.at(skinIndex)?.spotlight
-  const purchasedClipsBySkinClip = (clip: Clip, items: PassportItem[]) =>
-    (clip.link ? clip : undefined) ??
-    items.find((x) => x.assetId === clip.sTokenId)
+  const purchasedClipsBySkinClip = (clip: Clip, items: PassportItem[]) => {
+    const data =
+      (clip.link ? clip : undefined) ??
+      items.find((x) => x.assetId === clip.sTokenId)
+    return {
+      ...data,
+      id: clip?.id, // the id should always point to clip id and not assetDocId or passportDocId or anyother id.
+    }
+  }
 
   $: {
     spotlightLength = spotlight(profile)?.length ?? 0


### PR DESCRIPTION
- when combining clip data with passportItem doc and asset doc- the item doc or passport doc might overwrite the only 'id' property. so we reassign it to clip?.id. 

NOTE: need to test if this change breaks other things.